### PR TITLE
Update for Absinthe v1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /deps
 erl_crash.dump
 *.ez
+/doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# CHANGELOG
+
+Initial version.

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ See "Usage," below, for basic usage information.
 
 - For the tutorial, guides, and general information about Absinthe-related
   projects, see [http://absinthe-graphql.org](http://absinthe-graphql.org).
-- Links to the API documentation are available in the [project list](https://absinthe-graphql.org/projects).
+- Links to the API documentation are available in the [project list](http://absinthe-graphql.org/projects).
 
 ### Roadmap
 
-See the Roadmap on [absinthe-graphql.org](https://absinthe-graphql.org/roadmap).
+See the Roadmap on [absinthe-graphql.org](http://absinthe-graphql.org/roadmap).
 
 ## Related Projects
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,31 @@ _instead of_ `Absinthe.Schema`:
 use Absinthe.Relay.Schema
 ```
 
-This will automatically add the `:node` interface type and mark your schema as
-conforming to the `Absithe.Relay.Schema` behaviour.
+This will give you access to three new macros:
 
-Now, add the `node` field to your schema. You need to provide two functions to it:
+- `node_interface` - To define the node interface
+- `node_field` - To define the field used to lookup a node by a global ID
+- `node_object` - To define objects that represent nodes
 
-- `resolve` -  a resolver function that can lookup each each planned node type by `:type` and `:id`
-- `resolve_type` - a type resolver that, given a resolved object, returns the type identifier for the object (this is used to generate global IDs)
+First, add the node interface to your schema, providing a a type resolver that,
+given a resolved object, returns the type identifier for the object (this is
+used to generate global IDs):
+
+```elixir
+node_interface do
+  resolve_type fn
+     %{age: _}, _ ->
+       :person
+     %{employee_count: _}, _ ->
+       :business
+     _, _ ->
+       nil
+  end
+end
+```
+
+Now, add the `node` field to your schema, providing a `resolve` function used to
+lookup a node, given a type identifier and an ID:
 
 ```elixir
 query do
@@ -84,18 +102,12 @@ query do
       %{type: :business, id: id}, _ ->
         {:ok, Map.get(@businesses, id)}
     end
-    resolve_type fn
-      %{ships: _} ->
-        :faction
-      _ ->
-        :ship
-    end
   end
 
 end
 ```
 
-For your node types, use the `node_object` macro. This will automatically handle:
+Now, for your node types, use the `node_object` macro. This will automatically handle:
 
 * Adding `:node` to the object's interfaces list
 * Adding the required `:id` field using the global ID scheme

--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -1,7 +1,6 @@
 defmodule Absinthe.Relay.Connection do
 
-  use Absinthe.Type.Definitions
-  alias Absinthe.Type
+  use Absinthe.Schema.Notation
 
   @type t :: %{name: binary, type: atom, resolve_node: Absinthe.Execution.resolve_t, resolve_cursor: Absinthe.Execution.resolve_t, edge_fields: map, connection_fields: map}
   defstruct name: nil, type: nil, resolve_node: nil, resolve_cursor: nil, edge_fields: %{}, connection_fields: %{}

--- a/lib/absinthe/relay/node.ex
+++ b/lib/absinthe/relay/node.ex
@@ -1,9 +1,130 @@
 defmodule Absinthe.Relay.Node do
+  @moduledoc """
+
+  This module provides a macro `node` that should be used by schema
+  authors to add required "object identification" support for object
+  types, and to provide a unified interface for querying them.
+
+  More information can be found at:
+  - https://facebook.github.io/relay/docs/graphql-object-identification.html#content
+  - https://facebook.github.io/relay/graphql/objectidentification.htm
+
+  ## Interface
+
+  Define a node interface for your schema, providing a type resolver that,
+  given a resolved object can determine which node object type it belongs to.
+
+  ```
+  node interface do
+    resolve_type fn
+      %{age: _}, _ ->
+        :person
+      %{employee_count: _}, _ ->
+        :business
+      _, _ ->
+        nil
+    end
+  end
+  ```
+
+  This will create an interface, `:node` that expects one field, `:id`, be
+  defined -- and that the ID will be a global identifier.
+
+  If you use the `node` macro to create your `object` types (see "Object" below),
+  this can be easily done, layered on top of the standard object type definition
+  style.
+
+  ## Field
+
+  The node field provides a unified interface to query for an object in the
+  system using a global ID. The node field should be defined within your schema
+  `query` and should provide a resolver that, given a map containing the object
+  type identifier and internal, non-global ID (the incoming global ID will be
+  parsed into these values for you automatically) can resolve the correct value.
+
+  ```
+  query do
+
+    # ...
+
+    node field do
+      resolve fn
+        %{type: :person, id: id}, _ ->
+          {:ok, Map.get(@people, id)}
+        %{type: :business, id: id}, _ ->
+          {:ok, Map.get(@businesses, id)}
+      end
+    end
+
+  end
+  ```
+
+  This creates a field, `:node`, with one argument: `:id`. This is expected to
+  be a global ID and, once resolved, will result in a value whose type
+  implements the `:node` interface.
+
+  Here's how you easly create object types that can be looked up using this
+  field:
+
+  ## Object
+
+  To play nicely with the `:node` interface and field, explained above, any
+  object types need to implement the `:node` interface and generate a global
+  ID as the value of its `:id` field. Using the `node` macro, you can easily do
+  this while retaining the usual object type definition style.
+
+  ```
+  node object :person do
+    field :name, :string
+    field :age, :string
+  end
+  ```
+
+  This will create an object type, `:person`, as you might expect. An `:id`
+  field is created for you automatically, and this field generates a global ID;
+  a Base64 string that's built using the object type name and the raw, internal
+  identifier. All of this is handled for you automatically by prefixing your
+  object type definition with `"node "`.
+
+  The raw, internal value is retrieved using `default_id_fetcher/2` which just
+  pattern matches an `:id` field from the resolved object. If you need to
+  extract/build an internal ID via another method, just provide a function as
+  an `:id_fetcher` option.
+
+  For instance, assuming your raw internal IDs were stored as `:_id`, you could
+  configure your object like this:
+
+  ```
+  node object :thing, id_fetcher: &my_custom_id_fetcher/2 do
+    field :name, :string
+  end
+  ```
+  """
 
   alias Absinthe.Schema.Notation
 
-  defmacro node_interface([do: block]) do
-    __CALLER__
+  @doc """
+  Define a node interface, field, or object type for a schema.
+
+  See the module documentation for more information.
+  """
+  defmacro node({:interface, _, _}, [do: block]) do
+    do_interface(__CALLER__, block)
+  end
+  defmacro node({:field, _, _}, [do: block]) do
+    do_field(__CALLER__, block)
+  end
+  defmacro node({:object, _, [identifier | rest]}, [do: block]) do
+    do_object(__CALLER__, identifier, List.flatten(rest), block)
+  end
+
+  #
+  # INTERFACE
+  #
+
+  # Add the node interface
+  defp do_interface(env, block) do
+    env
     |> Notation.recordable!(:interface)
     |> record_interface!(:node, [], block)
     Notation.desc_attribute_recorder(:node)
@@ -19,18 +140,27 @@ defmodule Absinthe.Relay.Node do
       [interface_body, block]
     )
   end
+
+  # An id field is automatically configured
   defp interface_body do
     quote do
       field :id, non_null(:id), description: "The id of the object."
     end
   end
 
-  defmacro node_field([do: block]) do
-    __CALLER__
+  #
+  # FIELD
+  #
+
+  # Add the node field
+  defp do_field(env, block) do
+    env
     |> Notation.recordable!(:field)
     |> record_field!(:node, [type: :node], block)
   end
 
+  @doc false
+  # Record the node field
   def record_field!(env, identifier, attrs, block) do
     Notation.record_field!(
       env,
@@ -39,6 +169,8 @@ defmodule Absinthe.Relay.Node do
       [field_body, block]
     )
   end
+
+  # An id arg is automatically added
   defp field_body do
     quote do
       @desc "The id of an object."
@@ -46,23 +178,33 @@ defmodule Absinthe.Relay.Node do
     end
   end
 
+  #
+  # RESOLVE
+  #
+
   defmacro resolve(raw_func_ast) do
     env = __CALLER__
     func_ast = resolve_body(env, raw_func_ast)
     Notation.record_resolve!(env, func_ast)
   end
 
+  # Retrieve the AST for the resolver
+  # - Bare if this isn't for a node field.
+  # - Wrapped with global ID handling if
+  #   it is for a node field.
   defp resolve_body(env, raw_func_ast) do
-    case scopes_above(env) do
+    case scopes_status(env) do
       [{:field, :node}, {:object, :query}] ->
-        wrap_resolve(raw_func_ast)
+        resolve_with_global_id(raw_func_ast)
       _ ->
         Notation.recordable!(env, :resolve)
         raw_func_ast
     end
   end
 
-  defp scopes_above(env) do
+  # Get tuples representing the current state of the scope
+  # stack
+  defp scopes_status(env) do
     Notation.Scope.on(env.module)
     |> Enum.map(fn
       scope ->
@@ -71,7 +213,9 @@ defmodule Absinthe.Relay.Node do
     end)
   end
 
-  defp wrap_resolve(raw_func_ast) do
+  # Build a wrapper around a resolve function that
+  # parses the global ID before invoking it
+  defp resolve_with_global_id(raw_func_ast) do
     quote do
       fn
         %{id: global_id}, info ->
@@ -82,31 +226,39 @@ defmodule Absinthe.Relay.Node do
             other ->
               other
           end
-        args, info ->
-          IO.inspect(args: args, fields: info.definition)
+        _, info ->
           user_resolver = unquote(raw_func_ast)
           user_resolver.(%{}, info)
       end
     end
   end
 
-  defmacro node_object(identifier, [do: block]) do
-    record_object!(__CALLER__, identifier, [], block)
-  end
-  defmacro node_object(identifier, attrs, [do: block]) do
-    record_object!(__CALLER__, identifier, attrs, block)
+  #
+  # OBJECT
+  #
+
+  # Define a node object type
+  defp do_object(env, identifier, attrs, block) do
+    record_object!(env, identifier, attrs, block)
   end
 
+  @doc false
+  # Record a node object type
   def record_object!(env, identifier, attrs, block) do
     name = attrs[:name] || identifier |> Atom.to_string |> Absinthe.Utils.camelize
     Notation.record_object!(
       env,
       identifier,
-      attrs,
+      Keyword.delete(attrs, :id_fetcher),
       [object_body(name, attrs[:id_fetcher]), block]
     )
     Notation.desc_attribute_recorder(identifier)
   end
+
+  # Automatically add:
+  # - An id field that resolves to the generated global ID
+  #   for an object of this type
+  # - A declaration that this implements the node interface
   defp object_body(name, id_fetcher) do
     quote do
       @desc "The ID of an object"
@@ -117,6 +269,10 @@ defmodule Absinthe.Relay.Node do
     end
   end
 
+  @doc """
+  Parse a global ID, given a schema
+  """
+  @spec from_global_id(binary, atom) :: {:ok, %{type: atom, id: binary}} | {:error, binary}
   def from_global_id(global_id, schema) do
     case Base.decode64(global_id) do
       {:ok, decoded} ->
@@ -143,6 +299,10 @@ defmodule Absinthe.Relay.Node do
     {:error, "Could not extract value from decoded ID `#{decoded}'"}
   end
 
+  @doc """
+  Generate a global ID given a node type name and an internal (non-global) ID
+  """
+  @spec to_global_id(binary, binary) :: {:ok, binary} | {:error, binary}
   def to_global_id(_node_type, nil) do
     {:error, "No source non-global ID value present on object"}
   end
@@ -150,6 +310,7 @@ defmodule Absinthe.Relay.Node do
     {:ok, "#{node_type}:#{source_id}" |> Base.encode64}
   end
 
+  @doc false
   # The resolver for a global ID. If a type identifier instead of a type name
   # is used during field configuration, the type name needs to be looked up
   # during resolution.

--- a/lib/absinthe/relay/schema.ex
+++ b/lib/absinthe/relay/schema.ex
@@ -1,19 +1,12 @@
 defmodule Absinthe.Relay.Schema do
 
-  defmacro __using__(opts) do
+  defmacro __using__(_opts) do
     quote do
       use Absinthe.Schema
 
-      @behaviour unquote(__MODULE__)
-
-      @absinthe :type
-      def node do
-        Absinthe.Relay.Node.interface(&node_type_resolver/2)
-      end
+      import Absinthe.Relay.Node, only: :macros
 
     end
   end
-
-  @callback node_type_resolver(any, Absinthe.Execution.t) :: Absinthe.Type.t
 
 end

--- a/lib/absinthe/relay/schema.ex
+++ b/lib/absinthe/relay/schema.ex
@@ -2,7 +2,7 @@ defmodule Absinthe.Relay.Schema do
 
   defmacro __using__(_opts) do
     quote do
-      use Absinthe.Schema
+      use Absinthe.Schema, except: [resolve: 1]
 
       import Absinthe.Relay.Node, only: :macros
 

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule AbsintheRelay.Mixfile do
 
   defp deps do
     [
-      {:absinthe, github: "CargoSense/absinthe"},
+      {:absinthe, "~> 1.0"},
       {:poison, ">= 0.0.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.11.0", only: :dev},
       {:earmark, "~> 0.1.19", only: :dev},

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule AbsintheRelay.Mixfile do
 
   defp deps do
     [
-      {:absinthe, "~> 1.0"},
+      {:absinthe, github: "absinthe-graphql/absinthe", branch: "macro-extensibility"},
       {:poison, ">= 0.0.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.11.0", only: :dev},
       {:earmark, "~> 0.1.19", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"absinthe": {:git, "https://github.com/CargoSense/absinthe.git", "8c7add97fedeff7030c93c4ee764bd19390ce436", []},
+%{"absinthe": {:hex, :absinthe, "1.0.0"},
   "earmark": {:hex, :earmark, "0.1.19"},
   "ex_doc": {:hex, :ex_doc, "0.11.2"},
   "ex_spec": {:hex, :ex_spec, "1.0.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"absinthe": {:hex, :absinthe, "1.0.0"},
+%{"absinthe": {:git, "https://github.com/absinthe-graphql/absinthe.git", "c3b130ff5d9267fe7a27bd41a65fc1ae38ccaeaf", [branch: "macro-extensibility"]},
   "earmark": {:hex, :earmark, "0.1.19"},
   "ex_doc": {:hex, :ex_doc, "0.11.2"},
   "ex_spec": {:hex, :ex_spec, "1.0.0"},

--- a/test/lib/absinthe/relay/schema_test.exs
+++ b/test/lib/absinthe/relay/schema_test.exs
@@ -31,6 +31,7 @@ defmodule Absinthe.Relay.SchemaTest do
 
     end
 
+    @desc "My Interface"
     node_interface do
       resolve_type fn
         %{age: _}, _ ->
@@ -58,9 +59,16 @@ defmodule Absinthe.Relay.SchemaTest do
   @jill_global_id Base.encode64("Person:jill")
   @papers_global_id Base.encode64("Business:papers")
 
-  describe "using Absinthe.Relay.Schema" do
-    it "gives you the :node type automatically" do
-      assert %Type.Interface{name: "Node"} = Schema.__absinthe_types__(:node)
+  describe "using node_interface" do
+    it "creates the :node type" do
+      assert %Type.Interface{name: "Node", description: "My Interface", fields: %{id: %Type.Field{name: "id", type: %Type.NonNull{of_type: :id}}}} = Schema.__absinthe_type__(:node)
+    end
+  end
+
+  describe "using node_field" do
+    it "creates the :node field" do
+      assert %{fields: %{node: %{name: "node", type: :node, resolve: resolver}}} = Schema.__absinthe_type__(:query)
+      assert !is_nil(resolver)
     end
   end
 

--- a/test/support/star_wars/schema.ex
+++ b/test/support/star_wars/schema.ex
@@ -118,7 +118,6 @@ defmodule StarWars.Schema do
     end
   end
 
-
   @desc "A faction in the Star Wars saga"
   node_object :faction do
 
@@ -130,7 +129,7 @@ defmodule StarWars.Schema do
 
   end
 
-  node_object :ship_connection do
+  object :ship_connection do
     # ...
   end
 

--- a/test/support/star_wars/schema.ex
+++ b/test/support/star_wars/schema.ex
@@ -90,7 +90,7 @@ defmodule StarWars.Schema do
       end
     end
 
-    node_field do
+    node field do
       resolve fn
         %{type: node_type, id: id}, _ ->
           Database.get(node_type, id)
@@ -102,14 +102,14 @@ defmodule StarWars.Schema do
   end
 
   @desc "A ship in the Star Wars saga"
-  node_object :ship do
+  node object :ship do
 
     @desc "The name of the ship."
     field :name, :string
 
   end
 
-  node_interface do
+  node interface do
     resolve_type fn
       %{ships: _}, _ ->
         :faction
@@ -119,7 +119,7 @@ defmodule StarWars.Schema do
   end
 
   @desc "A faction in the Star Wars saga"
-  node_object :faction do
+  node object :faction do
 
     @desc "The name of the faction"
     field :name, :string

--- a/test/support/star_wars/schema.ex
+++ b/test/support/star_wars/schema.ex
@@ -73,70 +73,65 @@ defmodule StarWars.Schema do
   alias StarWars.Database
   use Absinthe.Relay.Schema
 
-  alias Absinthe.Type
-  alias Absinthe.Relay.Node
 
-  def query do
-    %Type.Object{
-      fields: fields(
-        rebels: [
-          type: :faction,
-          resolve: fn
-            _, _ ->
-              Database.get_rebels()
-          end
-        ],
-        empire: [
-          type: :faction,
-          resolve: fn
-            _, _ ->
-              Database.get_empire()
-          end
-        ],
-        node: Node.field(fn
-          %{type: node_type, id: id}, _ ->
-            Database.get(node_type, id)
-          _, _ ->
-            {:ok, nil}
-        end)
-      )
-    }
+  query do
+
+    field :rebels, :faction do
+      resolve fn
+        _, _ ->
+          Database.get_rebels()
+      end
+    end
+
+    field :empire, :faction do
+      resolve fn
+        _, _ ->
+          Database.get_empire()
+      end
+    end
+
+    node_field do
+      resolve fn
+        %{type: node_type, id: id}, _ ->
+          Database.get(node_type, id)
+        _, _ ->
+          {:ok, nil}
+      end
+    end
+
   end
 
-  @absinthe :type
-  def ship do
-    %Type.Object{
-      description: "A ship in the Star Wars saga",
-      fields: fields(
-        id: Node.global_id_field(:ship),
-        name: [type: :string, description: "The name of the ship."]
-      ),
-      interfaces: [:node]
-    }
+  @desc "A ship in the Star Wars saga"
+  node_object :ship do
+
+    @desc "The name of the ship."
+    field :name, :string
+
   end
 
-  def node_type_resolver(%{ships: _}, _), do: :faction
-  def node_type_resolver(_, _), do: :ship
-
-  @absinthe :type
-  def faction do
-    %Type.Object{
-      description: "A faction in the Star Wars saga",
-      fields: fields(
-        id: Node.global_id_field(:faction),
-        name: [type: :string, description: "The name of the faction"],
-        ships: [
-          type: :ship_connection,
-          description: "The ships used by the faction."
-        ]
-      ),
-      interfaces: [:node]
-    }
+  node_interface do
+    resolve_type fn
+      %{ships: _}, _ ->
+        :faction
+      _, _ ->
+        :ship
+    end
   end
 
-  @absinthe :type
-  def ship_connection do
-    %Type.Object{fields: fields([])}
+
+  @desc "A faction in the Star Wars saga"
+  node_object :faction do
+
+    @desc "The name of the faction"
+    field :name, :string
+
+    @desc "The ships used by the faction."
+    field :ships, :ship_connection
+
+  end
+
+  node_object :ship_connection do
+    # ...
   end
 
 end


### PR DESCRIPTION
This PR updates the schema notation used in the library to work with Absinthe v1.0, and introduces a nicer definition style for node-related schema mechanisms.

This _doesn't_ add Connection, which is the next sizable chunk of work.

Resolves #2 
