### PR TITLE
Add a parsing_node_ids helper to ease resolver use

### DIFF
--- a/lib/absinthe/relay/node/helpers.ex
+++ b/lib/absinthe/relay/node/helpers.ex
@@ -1,0 +1,43 @@
+defmodule Absinthe.Relay.Node.Helpers do
+
+  alias Absinthe.Relay.Node
+
+  @doc """
+  Wrap a resolver to parse node (global) ID arguments before it is executed.
+
+  ## Examples
+
+  Parse a node (global) ID argument `:item_id` (which should be an ID for the
+  `:item` type)
+
+  ```
+  resolve parsing_node_ids(&my_field_resolver/2, TheSchema, item_id: :item)
+  ```
+  """
+  def parsing_node_ids(resolver, schema, id_keys) do
+    fn args, info ->
+      args = Enum.reduce(id_keys, args, fn {key, type}, args ->
+        with {:ok, global_id} <- Map.fetch(args, key),
+             {:ok, %{id: id, type: ^type}} <- Node.from_global_id(global_id, schema) do
+          {:success, Map.put(args, key, id)}
+        end
+        |> case do
+             {:ok, %{type: bad_type}} ->
+               # The user provided an ID for a different type of field,
+               # notify them in a normal GraphQL error response
+               {:error, "Invalid node type for argument `#{key}`; should be #{type}, was #{bad_type}"}
+             {:error, msg} ->
+               # A more serious error, eg, a missing type, notify
+               # the schema designer with an exception
+               raise ArgumentError, msg
+             {:success, args} ->
+               args
+             _ ->
+               args
+           end
+      end)
+      resolver.(args, info)
+    end
+  end
+
+end

--- a/lib/absinthe/relay/node/helpers.ex
+++ b/lib/absinthe/relay/node/helpers.ex
@@ -11,14 +11,14 @@ defmodule Absinthe.Relay.Node.Helpers do
   `:item` type)
 
   ```
-  resolve parsing_node_ids(&my_field_resolver/2, TheSchema, item_id: :item)
+  resolve parsing_node_ids(&my_field_resolver/2, item_id: :item)
   ```
   """
-  def parsing_node_ids(resolver, schema, id_keys) do
+  def parsing_node_ids(resolver, id_keys) do
     fn args, info ->
       args = Enum.reduce(id_keys, args, fn {key, type}, args ->
         with {:ok, global_id} <- Map.fetch(args, key),
-             {:ok, %{id: id, type: ^type}} <- Node.from_global_id(global_id, schema) do
+             {:ok, %{id: id, type: ^type}} <- Node.from_global_id(global_id, info.schema) do
           {:success, Map.put(args, key, id)}
         end
         |> case do

--- a/lib/absinthe/relay/schema/notation.ex
+++ b/lib/absinthe/relay/schema/notation.ex
@@ -10,6 +10,7 @@ defmodule Absinthe.Relay.Schema.Notation do
     quote do
       import Absinthe.Relay.Mutation.Notation, only: :macros
       import Absinthe.Relay.Node.Notation, only: :macros
+      import Absinthe.Relay.Node.Helpers
       import Absinthe.Relay.Connection.Notation, only: :macros
     end
   end

--- a/test/lib/absinthe/relay/node_test.exs
+++ b/test/lib/absinthe/relay/node_test.exs
@@ -30,7 +30,7 @@ defmodule Absinthe.Relay.NodeTest do
     query do
       field :foo, :foo do
         arg :id, non_null(:id)
-        resolve parsing_node_ids(&resolve_foo/2, __MODULE__, id: :foo)
+        resolve parsing_node_ids(&resolve_foo/2, id: :foo)
       end
     end
 


### PR DESCRIPTION
This adds a function, `parsing_node_ids`, which can be used to wrap resolver functions to pre-parse node (global) ID arguments before they are passed on to the resolver.

This addresses the issue mentioned in #16.

## Example

Parse a node (global) ID argument `:item_id` (which should be an ID for the`:item` type)

```elixir
resolve parsing_node_ids(&my_field_resolver/2, item_id: :item)
```