### PR TITLE
Add test with redundant (but valid) duplicate fragments

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule AbsintheRelay.Mixfile do
 
   defp deps do
     [
-      {:absinthe, "~> 1.1.0"},
+      {:absinthe, "~> 1.1.6"},
       {:ecto, "~> 1.0 or ~> 2.0", optional: true},
       {:poison, ">= 0.0.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.11.0", only: :dev},

--- a/test/star_wars/object_identification_test.exs
+++ b/test/star_wars/object_identification_test.exs
@@ -41,6 +41,24 @@ defmodule StarWars.ObjectIdentificationTest do
       |> assert_data(%{"node" => %{"id" => "RmFjdGlvbjoy", "name" => "Galactic Empire"}})
     end
 
+    it "refetches the empire, with nested redundant Node fragment" do
+      """
+      query EmpireRefetchQueryWithExtraNodeFragment {
+        node(id: "RmFjdGlvbjoy") {
+          id
+          ... on Faction {
+            ... on Node {
+              ... on Faction {
+                name
+              }
+            }
+          }
+        }
+      }
+      """
+      |> assert_data(%{"node" => %{"id" => "RmFjdGlvbjoy", "name" => "Galactic Empire"}})
+    end
+
     it "refetches the X-Wing" do
       """
       query XWingRefetchQuery {


### PR DESCRIPTION
It seems I spoke too soon when I said my problem was fixed – there are still cases where mutations return empty objects because of the way Relay inserts `... on Node` lines. Here is an extra test demonstrating the problem.