### PR TITLE
Relax allowed ecto versions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule AbsintheRelay.Mixfile do
   defp deps do
     [
       {:absinthe, "~> 1.1.0"},
-      {:ecto, "~> 1.0 or ~> 2.0", optional: true},
+      {:ecto, "~> 1.0 or ~> 2.0 or ~> 2.0-rc", optional: true},
       {:poison, ">= 0.0.0", only: [:dev, :test]},
       {:ex_doc, "~> 0.11.0", only: :dev},
       {:earmark, "~> 0.2", only: :dev},


### PR DESCRIPTION
I'm using phoenix_ecto v3.0.0-rc.0, and it fails along with absinthe_relay:

```
Failed to use "ecto" (versions 2.0.0-beta.0 to 2.0.0-rc.5) because
  absinthe_relay (version 0.9.2) requires ~> 1.0 or ~> 2.0
  phoenix_ecto (version 3.0.0-rc.0) requires ~> 2.0.0-rc
```

This PR relaxes the constraint.