### PR TITLE
Fix warning

### DIFF
--- a/lib/absinthe/relay/mutation.ex
+++ b/lib/absinthe/relay/mutation.ex
@@ -93,7 +93,7 @@ defmodule Absinthe.Relay.Mutation do
             # On your own!
             other
         end
-      args, info ->
+      _args, info ->
         Absinthe.Resolution.call(designer_resolver, %{}, info)
     end
   end


### PR DESCRIPTION
```
warning: variable "args" is unused
  lib/absinthe/relay/mutation.ex:96
```