### PR TITLE
Use Keyword.get/3 to read keyword list options

### DIFF
--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -275,14 +275,13 @@ defmodule Absinthe.Relay.Connection do
   @spec from_slice(data :: list, offset :: offset) :: t
   @spec from_slice(data :: list, offset :: offset, opts :: from_slice_opts) :: t
   def from_slice(items, offset, opts \\ []) do
-    opts = Map.new(opts)
     {edges, first, last} = build_cursors(items, offset)
 
     page_info = %{
       start_cursor: first,
       end_cursor: last,
-      has_previous_page: Map.get(opts, :has_previous_page, false),
-      has_next_page: Map.get(opts, :has_next_page, false),
+      has_previous_page: Keyword.get(opts, :has_previous_page, false),
+      has_next_page: Keyword.get(opts, :has_next_page, false),
     }
     %{edges: edges, page_info: page_info}
   end


### PR DESCRIPTION
This lets us drop an otherwise unnecessary intermediate Map creation.