### PR TITLE
Remove note about being pre-1.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ Support for the [Relay framework](https://facebook.github.io/relay/)
 from Elixir, using the [Absinthe](https://github.com/absinthe-graphql/absinthe)
 package.
 
-Please note that this is the initial release of this package and that
-significant API changes are expected before v1.0.
-
 ## Installation
 
 Install from [Hex.pm](https://hex.pm/packages/absinthe_relay):


### PR DESCRIPTION
Nothing major, but it does throw you off when reading the README at first. Considering the package is at > 1.0, it seems wise to remove this notice.