### PR TITLE
Make client_mutation_id input field optional as in Relay Modern.

### DIFF
--- a/lib/absinthe/relay/mutation.ex
+++ b/lib/absinthe/relay/mutation.ex
@@ -91,6 +91,11 @@ defmodule Absinthe.Relay.Mutation do
           private: Map.put(res.private, :__client_mutation_id, mut_id),
           middleware: res.middleware ++ [__MODULE__]
         }
+      %{input: input} ->
+        %{res |
+          arguments: input,
+          middleware: res.middleware ++ [__MODULE__]
+        }
       res ->
         res
     end

--- a/lib/absinthe/relay/mutation/notation.ex
+++ b/lib/absinthe/relay/mutation/notation.ex
@@ -87,7 +87,7 @@ defmodule Absinthe.Relay.Mutation.Notation do
   # Common for both the input and payload objects
   defp client_mutation_id_field do
     quote do
-      field :client_mutation_id, type: non_null(:string)
+      field :client_mutation_id, type: :string
     end
   end
 

--- a/test/lib/absinthe/relay/mutation_test.exs
+++ b/test/lib/absinthe/relay/mutation_test.exs
@@ -59,6 +59,58 @@ defmodule Absinthe.Relay.MutationTest do
     end
   end
 
+  describe "mutation WITHOUT clientMutationId" do
+
+    @query """
+    mutation M {
+      simpleMutation {
+        result
+      }
+    }
+    """
+    it "requires an `input' argument" do
+      assert {:ok, %{errors: [%{message: ~s(In argument "input": Expected type "SimpleMutationInput!", found null.)}]}} = Absinthe.run(@query, Schema)
+    end
+
+    @query """
+    mutation M {
+      simpleMutation(input: {input_data: 1}) {
+        result
+        clientMutationId
+      }
+    }
+    """
+    @expected %{
+      data: %{
+        "simpleMutation" => %{
+          "result" => 2,
+          "clientMutationId" => nil
+        }
+      }
+    }
+    it "returns nil clientMutationId" do
+      assert {:ok, @expected} == Absinthe.run(@query, Schema)
+    end
+
+    @query """
+    mutation M {
+      simpleMutation(input: {input_data: 1}) {
+        result
+      }
+    }
+    """
+    @expected %{
+      data: %{
+        "simpleMutation" => %{
+          "result" => 2
+        }
+      }
+    }
+    it "works without querying clientMutationId in the payload" do
+      assert {:ok, @expected} == Absinthe.run(@query, Schema)
+    end
+  end
+
 
   describe "introspection" do
 
@@ -90,12 +142,9 @@ defmodule Absinthe.Relay.MutationTest do
             %{
               "name" => "clientMutationId",
               "type" => %{
-                "name" => nil,
-                "kind" => "NON_NULL",
-                "ofType" => %{
-                  "name" => "String",
-                  "kind" => "SCALAR"
-                }
+                "name" => "String",
+                "kind" => "SCALAR",
+                "ofType" => nil
               }
             },
             %{
@@ -143,12 +192,9 @@ defmodule Absinthe.Relay.MutationTest do
             %{
               "name" => "clientMutationId",
               "type" => %{
-                "name" => nil,
-                "kind" => "NON_NULL",
-                "ofType" => %{
-                  "name" => "String",
-                  "kind" => "SCALAR"
-                }
+                "name" => "String",
+                "kind" => "SCALAR",
+                "ofType" => nil
               }
             },
             %{


### PR DESCRIPTION
Hi guys,

In Relay Modern `clientMutationId` is not mandatory anymore. This pull request just removes the `NON_NULL` type validation from the `:client_mutation_id` field created by the `payload` macro.

Regards,

Hisa
