### PR TITLE
Documentation changes on Connection limit and offset_and_limit_for_query

### DIFF
--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -361,7 +361,7 @@ defmodule Absinthe.Relay.Connection do
 
       {:ok, :backward, limit} ->
         case {offset(args), opts[:count]} do
-          {nil, nil} -> {:error, "You must supply a count if using `last` without `before`"}
+          {nil, nil} -> {:error, "You must supply a count (total number of records) option if using `last` without `before`"}
           {nil, value} -> {:ok, max(value - limit, 0), limit}
           {value, _} -> {:ok, max(value - limit, 0), limit}
         end

--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -268,7 +268,7 @@ defmodule Absinthe.Relay.Connection do
   alias Absinthe.Relay
 
   def list(args, %{context: %{current_user: user}}) do
-    {:forward, limit} = Connection.limit(args)
+    {:ok, :forward, limit} = Connection.limit(args)
     offset = Connection.offset(args)
 
     Post


### PR DESCRIPTION
The `offset_and_limit_for_query` change is because I couldn't figure out what that error meant until I read the source code a couple of times. I know that's only evidence from one person, but I hope it can help someone else in the future.