### PR TITLE
fix arithmetic error when offset is nil

### DIFF
--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -415,6 +415,7 @@ defmodule Absinthe.Relay.Connection do
 
   defp build_cursors([], _offset), do: {[], nil, nil}
   defp build_cursors([item | items], offset) do
+    offset = offset || 0
     first = offset_to_cursor(offset)
     first_edge = %{
       node: item,

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -1,6 +1,8 @@
 defmodule Absinthe.Relay.ConnectionTest do
   use Absinthe.Relay.Case, async: true
 
+  alias Absinthe.Relay.Connection
+
   @jack_global_id Base.encode64("Person:jack")
 
   defmodule CustomConnectionAndEdgeFieldsSchema do
@@ -189,4 +191,9 @@ defmodule Absinthe.Relay.ConnectionTest do
     end
   end
 
+  describe ".from_slice/2" do
+    it "when the offset is nil it will not do arithmetic on nil" do
+      Connection.from_slice([%{foo: :bar}], nil)
+    end
+  end
 end


### PR DESCRIPTION
Hey guys, I was running some code and I discovered that the `Connection.offset(args)` will return `nil` if the `args` do not specify an offset. Since there is a `nil` return and we do `Connection.from_slice(posts, offset)` we will get, as I generated from the test:

```elixir
  1) test .from_slice/2 when the offset is nil it will set default offset to 1 (Absinthe.Relay.ConnectionTest)
     test/lib/absinthe/relay/connection_test.exs:195
     ** (ArithmeticError) bad argument in arithmetic expression
     code: Connection.from_slice([%{foo: :bar}], nil)
     stacktrace:
       (absinthe_relay) lib/absinthe/relay/connection.ex:425: Absinthe.Relay.Connection.build_cursors/2
       (absinthe_relay) lib/absinthe/relay/connection.ex:287: Absinthe.Relay.Connection.from_slice/3
       test/lib/absinthe/relay/connection_test.exs:196: (test)
```

To mitigate this, I'm setting offset with a fallback value of `0` in case `nil` is passed in.