### PR TITLE
Modernize Tests

### DIFF
--- a/lib/absinthe/relay/schema/notation.ex
+++ b/lib/absinthe/relay/schema/notation.ex
@@ -26,13 +26,14 @@ defmodule Absinthe.Relay.Schema.Notation do
     [
       # TODO: Remove warning in v1.5
       quote do
-        warning =
-          "Defaulting to :classic as the flavor of Relay to target. " <>
-          "Note this defaulting behavior will change to :modern in absinthe_relay v1.5. " <>
-          "To prevent seeing this notice in the future, provide :classic " <>
-          "or :modern as an option when using Absinthe.Relay.Schema or " <>
-          "Absinthe.Relay.Schema.Notation. See the Absinthe.Relay @moduledoc " <>
-          "for more information."
+        warning = """
+        Defaulting to :classic as the flavor of Relay to target. \
+        Note this defaulting behavior will change to :modern in absinthe_relay v1.5. \
+        To prevent seeing this notice in the meantime, explicitly provide :classic \
+        or :modern as an option when you use Absinthe.Relay.Schema or \
+        Absinthe.Relay.Schema.Notation. See the Absinthe.Relay @moduledoc \
+        for more information. \
+        """
         IO.warn(warning)
       end,
       notations(@default_flavor)

--- a/mix.exs
+++ b/mix.exs
@@ -33,12 +33,11 @@ defmodule AbsintheRelay.Mixfile do
 
   defp deps do
     [
-      {:absinthe, "~> 1.3.0"},
+      {:absinthe, "~> 1.4.0-beta or ~> 1.4.0-rc or ~> 1.4"},
       {:ecto, "~> 1.0 or ~> 2.0", optional: true},
       {:poison, ">= 0.0.0", only: [:dev, :test]},
-      {:ex_doc, "~> 0.11.0", only: :dev},
-      {:earmark, "~> 0.2", only: :dev},
-      {:ex_spec, "~> 1.0.0", only: :test}
+      {:ex_doc, "~> 0.16", only: :dev},
+      {:earmark, "~> 1.1", only: :dev}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
-%{"absinthe": {:hex, :absinthe, "1.3.0", "0b58aec87c115025c6abbbdaebdd2b5d545d5c47a342e5a8c790d5989d27b24c", [:mix], []},
+%{"absinthe": {:hex, :absinthe, "1.4.0-beta.4", "06726ebcb2d564f9b02b8511c75ddb38ffbbd45dfd2a88dcb80181486f61442f", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
-  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "2.1.4", "d1ba932813ec0e0d9db481ef2c17777f1cefb11fc90fa7c142ff354972dfba7e", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
-  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_spec": {:hex, :ex_spec, "1.0.0", "b1e791072fecbf80c725adf45e7cbdf3d96af3765638a1f1547824706ece4bc9", [:mix], []},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -7,7 +7,7 @@ defmodule Absinthe.Relay.ConnectionTest do
 
   defmodule CustomConnectionAndEdgeFieldsSchema do
     use Absinthe.Schema
-    use Absinthe.Relay.Schema
+    use Absinthe.Relay.Schema, :classic
 
     @people %{
       "jack" => %{id: "jack", name: "Jack", age: 35, pets: ["1", "2"], favorite_pets: ["2"]},
@@ -110,7 +110,7 @@ defmodule Absinthe.Relay.ConnectionTest do
   end
 
   describe "Defining custom connection and edge fields" do
-    it " allows querying those additional fields" do
+    test " allows querying those additional fields" do
       result = """
         query FirstPetName($personId: ID!) {
           node(id: $personId) {
@@ -145,7 +145,7 @@ defmodule Absinthe.Relay.ConnectionTest do
   end
 
   describe "Defining custom connection and edge fields, with redundant spread fragments" do
-    it " allows querying those additional fields" do
+    test " allows querying those additional fields" do
       result = """
         query FirstPetName($personId: ID!) {
           node(id: $personId) {
@@ -192,7 +192,7 @@ defmodule Absinthe.Relay.ConnectionTest do
   end
 
   describe ".from_slice/2" do
-    it "when the offset is nil it will not do arithmetic on nil" do
+    test "when the offset is nil test will not do arithmetic on nil" do
       Connection.from_slice([%{foo: :bar}], nil)
     end
   end

--- a/test/lib/absinthe/relay/mutation/classic_test.exs
+++ b/test/lib/absinthe/relay/mutation/classic_test.exs
@@ -1,9 +1,9 @@
-defmodule Absinthe.Relay.MutationTest do
+defmodule Absinthe.Relay.Mutation.ClassicTest do
   use Absinthe.Relay.Case, async: true
 
   defmodule Schema do
     use Absinthe.Schema
-    use Absinthe.Relay.Schema
+    use Absinthe.Relay.Schema, :classic
 
     query do
     end
@@ -34,7 +34,7 @@ defmodule Absinthe.Relay.MutationTest do
       }
     }
     """
-    it "requires an `input' argument" do
+    test "requires an `input' argument" do
       assert {:ok, %{errors: [%{message: ~s(In argument "input": Expected type "SimpleMutationInput!", found null.)}]}} = Absinthe.run(@query, Schema)
     end
 
@@ -54,7 +54,7 @@ defmodule Absinthe.Relay.MutationTest do
         }
       }
     }
-    it "returns the same client mutation ID and resolves as expected" do
+    test "returns the same client mutation ID and resolves as expected" do
       assert {:ok, @expected} == Absinthe.run(@query, Schema)
     end
   end
@@ -111,7 +111,7 @@ defmodule Absinthe.Relay.MutationTest do
         }
       }
     }
-    it "contains correct input" do
+    test "contains correct input" do
       assert {:ok, @expected} = Absinthe.run(@query, Schema)
     end
 
@@ -164,7 +164,7 @@ defmodule Absinthe.Relay.MutationTest do
       }
     }
 
-    it "contains correct payload" do
+    test "contains correct payload" do
       assert {:ok, @expected} == Absinthe.run(@query, Schema)
     end
 
@@ -227,7 +227,7 @@ defmodule Absinthe.Relay.MutationTest do
     }
   }
 
-  it "returns the correct field" do
+  test "returns the correct field" do
     assert {:ok, @expected} == Absinthe.run(@query, Schema)
   end
 
@@ -235,7 +235,7 @@ defmodule Absinthe.Relay.MutationTest do
 
     defmodule EmptyInputAndResultSchema do
       use Absinthe.Schema
-      use Absinthe.Relay.Schema
+      use Absinthe.Relay.Schema, :classic
 
       query do
 
@@ -265,7 +265,7 @@ defmodule Absinthe.Relay.MutationTest do
       }
     }
     """
-    it "supports returning the client mutation id intact when defined without a block" do
+    test "supports returning the client mutation id intact when defined without a block" do
       assert {:ok, %{data: %{"withoutBlock" => %{"clientMutationId" => @cm_id}}}} == Absinthe.run(@query, EmptyInputAndResultSchema)
     end
 
@@ -276,7 +276,7 @@ defmodule Absinthe.Relay.MutationTest do
       }
     }
     """
-    it "supports returning the client mutation id intact when defined with a block" do
+    test "supports returning the client mutation id intact when defined with a block" do
       assert {:ok, %{data: %{"withBlock" => %{"clientMutationId" => @cm_id}}}} == Absinthe.run(@query, EmptyInputAndResultSchema)
     end
 
@@ -287,7 +287,7 @@ defmodule Absinthe.Relay.MutationTest do
       }
     }
     """
-    it "supports returning the client mutation id intact when defined with a block and attrs" do
+    test "supports returning the client mutation id intact when defined with a block and attrs" do
       assert {:ok, %{data: %{"withBlockAndAttrs" => %{"clientMutationId" => @cm_id}}}} == Absinthe.run(@query, EmptyInputAndResultSchema)
     end
 

--- a/test/lib/absinthe/relay/mutation/modern_test.exs
+++ b/test/lib/absinthe/relay/mutation/modern_test.exs
@@ -1,4 +1,4 @@
-defmodule Absinthe.Relay.MutationModernTest do
+defmodule Absinthe.Relay.Mutation.ModernTest do
   use Absinthe.Relay.Case, async: true
 
   defmodule Schema do
@@ -34,7 +34,7 @@ defmodule Absinthe.Relay.MutationModernTest do
       }
     }
     """
-    it "requires an `input' argument" do
+    test "requires an `input' argument" do
       assert {:ok, %{errors: [%{message: ~s(In argument "input": Expected type "SimpleMutationInput!", found null.)}]}} = Absinthe.run(@query, Schema)
     end
 
@@ -54,7 +54,7 @@ defmodule Absinthe.Relay.MutationModernTest do
         }
       }
     }
-    it "returns the same client mutation ID and resolves as expected" do
+    test "returns the same client mutation ID and resolves as expected" do
       assert {:ok, @expected} == Absinthe.run(@query, Schema)
     end
   end
@@ -68,7 +68,7 @@ defmodule Absinthe.Relay.MutationModernTest do
       }
     }
     """
-    it "requires an `input' argument" do
+    test "requires an `input' argument" do
       assert {:ok, %{errors: [%{message: ~s(In argument "input": Expected type "SimpleMutationInput!", found null.)}]}} = Absinthe.run(@query, Schema)
     end
 
@@ -88,7 +88,7 @@ defmodule Absinthe.Relay.MutationModernTest do
         }
       }
     }
-    it "returns nil clientMutationId" do
+    test "returns nil clientMutationId" do
       assert {:ok, @expected} == Absinthe.run(@query, Schema)
     end
 
@@ -106,7 +106,7 @@ defmodule Absinthe.Relay.MutationModernTest do
         }
       }
     }
-    it "works without querying clientMutationId in the payload" do
+    test "works without querying clientMutationId in the payload" do
       assert {:ok, @expected} == Absinthe.run(@query, Schema)
     end
   end
@@ -160,7 +160,7 @@ defmodule Absinthe.Relay.MutationModernTest do
         }
       }
     }
-    it "contains correct input" do
+    test "contains correct input" do
       assert {:ok, @expected} = Absinthe.run(@query, Schema)
     end
 
@@ -210,7 +210,7 @@ defmodule Absinthe.Relay.MutationModernTest do
       }
     }
 
-    it "contains correct payload" do
+    test "contains correct payload" do
       assert {:ok, @expected} == Absinthe.run(@query, Schema)
     end
 
@@ -273,7 +273,7 @@ defmodule Absinthe.Relay.MutationModernTest do
     }
   }
 
-  it "returns the correct field" do
+  test "returns the correct field" do
     assert {:ok, @expected} == Absinthe.run(@query, Schema)
   end
 
@@ -281,7 +281,7 @@ defmodule Absinthe.Relay.MutationModernTest do
 
     defmodule EmptyInputAndResultSchema do
       use Absinthe.Schema
-      use Absinthe.Relay.Schema
+      use Absinthe.Relay.Schema, :modern
 
       query do
 
@@ -311,7 +311,7 @@ defmodule Absinthe.Relay.MutationModernTest do
       }
     }
     """
-    it "supports returning the client mutation id intact when defined without a block" do
+    test "supports returning the client mutation id intact when defined without a block" do
       assert {:ok, %{data: %{"withoutBlock" => %{"clientMutationId" => @cm_id}}}} == Absinthe.run(@query, EmptyInputAndResultSchema)
     end
 
@@ -322,7 +322,7 @@ defmodule Absinthe.Relay.MutationModernTest do
       }
     }
     """
-    it "supports returning the client mutation id intact when defined with a block" do
+    test "supports returning the client mutation id intact when defined with a block" do
       assert {:ok, %{data: %{"withBlock" => %{"clientMutationId" => @cm_id}}}} == Absinthe.run(@query, EmptyInputAndResultSchema)
     end
 
@@ -333,7 +333,7 @@ defmodule Absinthe.Relay.MutationModernTest do
       }
     }
     """
-    it "supports returning the client mutation id intact when defined with a block and attrs" do
+    test "supports returning the client mutation id intact when defined with a block and attrs" do
       assert {:ok, %{data: %{"withBlockAndAttrs" => %{"clientMutationId" => @cm_id}}}} == Absinthe.run(@query, EmptyInputAndResultSchema)
     end
 

--- a/test/lib/absinthe/relay/node/parse_ids_test.exs
+++ b/test/lib/absinthe/relay/node/parse_ids_test.exs
@@ -17,7 +17,7 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
 
   defmodule Schema do
     use Absinthe.Schema
-    use Absinthe.Relay.Schema
+    use Absinthe.Relay.Schema, :classic
 
     alias Absinthe.Relay.Node.ParseIDsTest.Foo
     alias Absinthe.Relay.Node.ParseIDsTest.Parent
@@ -166,7 +166,7 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
   @foo1_id Base.encode64("Foo:1")
   @foo2_id Base.encode64("Foo:2")
 
-  it "parses one id correctly" do
+  test "parses one id correctly" do
     result =
       """
       {
@@ -180,7 +180,7 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
     assert {:ok, %{data: %{"foo" => %{"name" => "Foo 1", "id" => @foo1_id}}}} == result
   end
 
-  it "parses a list of ids correctly" do
+  test "parses a list of ids correctly" do
     result =
       """
       {
@@ -200,7 +200,7 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
     } == result
   end
 
-  it "parses an id into one of multiple node types" do
+  test "parses an id into one of multiple node types" do
     result =
       """
       {
@@ -212,7 +212,7 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
   end
 
   @tag :focus
-  it "parses nested ids" do
+  test "parses nested ids" do
     encoded_parent_id = Base.encode64("Parent:1")
     encoded_child1_id = Base.encode64("Child:1")
     encoded_child2_id = Base.encode64("Child:1")
@@ -249,7 +249,7 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
     assert {:ok, %{data: %{"updateParent" => expected_parent_data}}} == result
   end
 
-  it "parses incorrect nested ids" do
+  test "parses incorrect nested ids" do
     encoded_parent_id = Base.encode64("Parent:1")
     incorrect_id = Node.to_global_id(:other_foo, 1, Schema)
     mutation =
@@ -279,7 +279,7 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
     } = result
   end
 
-  it "handles one incorrect id correctly" do
+  test "handles one incorrect id correctly" do
     result =
       """
       {
@@ -300,7 +300,7 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
     } = result
   end
 
- it "parses nested ids with local middleware" do
+ test "parses nested ids with local middleware" do
     encoded_parent_id = Base.encode64("Parent:1")
     encoded_child1_id = Base.encode64("Child:1")
     encoded_child2_id = Base.encode64("Child:1")

--- a/test/lib/absinthe/relay/node_test.exs
+++ b/test/lib/absinthe/relay/node_test.exs
@@ -5,7 +5,7 @@ defmodule Absinthe.Relay.NodeTest do
 
   defmodule Schema do
     use Absinthe.Schema
-    use Absinthe.Relay.Schema
+    use Absinthe.Relay.Schema, :classic
 
     @foos %{
       "1" => %{id: "1", name: "Bar 1"},
@@ -87,27 +87,27 @@ defmodule Absinthe.Relay.NodeTest do
 
   describe "to_global_id" do
 
-    it "works given an atom for an existing type" do
+    test "works given an atom for an existing type" do
       assert !is_nil(Node.to_global_id(:foo, 1, Schema))
     end
 
-    it "returns an atom for an non-existing type" do
+    test "returns an atom for an non-existing type" do
       assert is_nil(Node.to_global_id(:not_foo, 1, Schema))
     end
 
-    it "works given a binary and internal ID" do
+    test "works given a binary and internal ID" do
       assert Node.to_global_id("Foo", 1)
     end
 
-    it "gives the same global ID for different type, equivalent references" do
+    test "gives the same global ID for different type, equivalent references" do
       assert Node.to_global_id("FancyFoo", 1) == Node.to_global_id(:other_foo, 1, Schema)
     end
 
-    it "gives the different global ID for different type, equivalent references" do
+    test "gives the different global ID for different type, equivalent references" do
       assert Node.to_global_id("FancyFoo", 1) != Node.to_global_id(:foo, 1, Schema)
     end
 
-    it "fails given a bad ID" do
+    test "fails given a bad ID" do
       assert is_nil(Node.to_global_id("Foo", nil))
     end
 
@@ -115,14 +115,14 @@ defmodule Absinthe.Relay.NodeTest do
 
   describe "parsing_node_id" do
 
-    it "parses one id correctly" do
+    test "parses one id correctly" do
       result =
         ~s<{ singleFoo(id: "#{@foo1_id}") { id name } }>
         |> Absinthe.run(Schema)
       assert {:ok, %{data: %{"singleFoo" => %{"name" => "Bar 1", "id" => @foo1_id}}}} == result
     end
 
-    it "handles one incorrect id with a single expected type" do
+    test "handles one incorrect id with a single expected type" do
       result =
         ~s<{ singleFoo(id: "#{Node.to_global_id(:other_foo, 1, Schema)}") { id name } }>
         |> Absinthe.run(Schema)
@@ -131,7 +131,7 @@ defmodule Absinthe.Relay.NodeTest do
       ]}} = result
     end
 
-    it "handles one incorrect id with a multiple expected types" do
+    test "handles one incorrect id with a multiple expected types" do
       result =
         ~s<{ singleFooWithMultipleNodeTypes(id: "#{Node.to_global_id(:other_foo, 1, Schema)}") { id name } }>
         |> Absinthe.run(Schema)
@@ -140,14 +140,14 @@ defmodule Absinthe.Relay.NodeTest do
       ]}} = result
     end
 
-    it "handles one correct id with a multiple expected types" do
+    test "handles one correct id with a multiple expected types" do
       result =
         ~s<{ singleFooWithMultipleNodeTypes(id: "#{@foo1_id}") { id name } }>
         |> Absinthe.run(Schema)
       assert {:ok, %{data: %{"singleFooWithMultipleNodeTypes" => %{"name" => "Bar 1", "id" => @foo1_id}}}} == result
     end
 
-    it "parses multiple ids correctly" do
+    test "parses multiple ids correctly" do
       result =
         ~s<{ dualFoo(id1: "#{@foo1_id}", id2: "#{@foo2_id}") { id name } }>
         |> Absinthe.run(Schema)
@@ -157,7 +157,7 @@ defmodule Absinthe.Relay.NodeTest do
       ]}}} == result
     end
 
-    it "handles multiple incorrect ids" do
+    test "handles multiple incorrect ids" do
       result =
         ~s<{ dualFoo(id1: "#{Node.to_global_id(:other_foo, 1, Schema)}", id2: "#{Node.to_global_id(:other_foo, 2, Schema)}") { id name } }>
         |> Absinthe.run(Schema)
@@ -167,7 +167,7 @@ defmodule Absinthe.Relay.NodeTest do
       ]}} = result
     end
 
-    it "handles multiple incorrect ids with multiple node types" do
+    test "handles multiple incorrect ids with multiple node types" do
       result =
         ~s<{ dualFooWithMultipleNodeTypes(id1: "#{Node.to_global_id(:other_foo, 1, Schema)}", id2: "#{Node.to_global_id(:other_foo, 2, Schema)}") { id name } }>
         |> Absinthe.run(Schema)
@@ -178,7 +178,7 @@ defmodule Absinthe.Relay.NodeTest do
     end
 
 
-    it "parses multiple ids correctly with multiple node types" do
+    test "parses multiple ids correctly with multiple node types" do
       result =
         ~s<{ dualFooWithMultipleNodeTypes(id1: "#{@foo1_id}", id2: "#{@foo2_id}") { id name } }>
         |> Absinthe.run(Schema)

--- a/test/lib/absinthe/relay/pagination_test.exs
+++ b/test/lib/absinthe/relay/pagination_test.exs
@@ -3,7 +3,7 @@ defmodule Absinthe.Relay.PaginationTest do
 
   defmodule Schema do
     use Absinthe.Schema
-    use Absinthe.Relay.Schema
+    use Absinthe.Relay.Schema, :classic
 
     @foos 0..9 |> Enum.map(&(%{id: &1, index: &1}))
 

--- a/test/lib/absinthe/relay/schema_test.exs
+++ b/test/lib/absinthe/relay/schema_test.exs
@@ -11,7 +11,7 @@ defmodule Absinthe.Relay.SchemaTest do
 
   defmodule Schema do
     use Absinthe.Schema
-    use Absinthe.Relay.Schema
+    use Absinthe.Relay.Schema, :classic
 
     @people %{"jack" => %{id: "jack", name: "Jack", age: 35},
               "jill" => %{id: "jill", name: "Jill", age: 31}}
@@ -76,20 +76,20 @@ defmodule Absinthe.Relay.SchemaTest do
   end
 
   describe "using node interface" do
-    it "creates the :node type" do
+    test "creates the :node type" do
       assert %Type.Interface{name: "Node", description: "My Interface", fields: %{id: %Type.Field{name: "id", type: %Type.NonNull{of_type: :id}}}} = Schema.__absinthe_type__(:node)
     end
   end
 
   describe "using node field" do
-    it "creates the :node field" do
+    test "creates the :node field" do
       assert %{fields: %{node: %{name: "node", type: :node, middleware: middleware}}} = Schema.__absinthe_type__(:query)
       assert [{{Absinthe.Relay.Node, :resolve_with_global_id}, []}, {{Absinthe.Resolution, :call}, _}] = middleware
     end
   end
 
   describe "using node object" do
-    it "creates the object" do
+    test "creates the object" do
       assert %{name: "Kitten"} = Schema.__absinthe_type__(:cat)
     end
   end
@@ -103,7 +103,7 @@ defmodule Absinthe.Relay.SchemaTest do
       }
     }
     """
-    it "resolves using the global ID" do
+    test "resolves using the global ID" do
       assert {:ok, %{data: %{"node" => %{"id" => @jack_global_id, "name" => "Jack"}}}} = Absinthe.run(@query, Schema)
     end
   end
@@ -117,7 +117,7 @@ defmodule Absinthe.Relay.SchemaTest do
       }
     }
     """
-    it "resolves using the global ID" do
+    test "resolves using the global ID" do
       assert {:ok, %{data: %{"node" => %{"id" => @papers_global_id, "name" => "Papers, Inc!"}}}} = Absinthe.run(@query, Schema)
     end
   end
@@ -130,7 +130,7 @@ defmodule Absinthe.Relay.SchemaTest do
       }
     }
     """
-    it "resolves using the global ID" do
+    test "resolves using the global ID" do
       assert {:ok, %{data: %{"node" => %{"id" => @binx_global_id}}}} = Absinthe.run(@query, Schema)
     end
   end

--- a/test/star_wars/connection_test.exs
+++ b/test/star_wars/connection_test.exs
@@ -2,7 +2,7 @@ defmodule StarWars.ConnectionTest do
   use Absinthe.Relay.Case, async: true
 
   describe "Backwards Pagination" do
-    it "can start from the end of a list" do
+    test "can start from the end of a list" do
       query = """
         query RebelsShipsQuery {
           rebels {
@@ -54,7 +54,7 @@ defmodule StarWars.ConnectionTest do
       assert {:ok, %{data: expected}} == Absinthe.run(query, StarWars.Schema)
     end
 
-    it "should calculate hasNextPage correctly" do
+    test "should calculate hasNextPage correctly" do
       query = """
         query RebelsShipsQuery {
           rebels {
@@ -119,7 +119,7 @@ defmodule StarWars.ConnectionTest do
 
   describe "Star Wars connections" do
 
-    it "fetches the first ship of the rebels" do
+    test "fetches the first ship of the rebels" do
       query = """
         query RebelsShipsQuery {
           rebels {
@@ -151,7 +151,7 @@ defmodule StarWars.ConnectionTest do
       assert {:ok, %{data: expected}} == Absinthe.run(query, StarWars.Schema)
     end
 
-    it "fetches the first two ships of the rebels with a cursor" do
+    test "fetches the first two ships of the rebels with a cursor" do
       query = """
         query MoreRebelShipsQuery {
           rebels {
@@ -191,7 +191,7 @@ defmodule StarWars.ConnectionTest do
       assert {:ok, %{data: expected}} == Absinthe.run(query, StarWars.Schema)
     end
 
-    it "fetches the next three ships of the rebels with a cursor" do
+    test "fetches the next three ships of the rebels with a cursor" do
       query = """
         query EndOfRebelShipsQuery {
           rebels {
@@ -237,7 +237,7 @@ defmodule StarWars.ConnectionTest do
       assert {:ok, %{data: expected}} == Absinthe.run(query, StarWars.Schema)
     end
 
-    it "fetches no ships of the rebels at the end of connection" do
+    test "fetches no ships of the rebels at the end of connection" do
       query = """
         query RebelsQuery {
           rebels {
@@ -264,7 +264,7 @@ defmodule StarWars.ConnectionTest do
       assert {:ok, %{data: expected}} == Absinthe.run(query, StarWars.Schema)
     end
 
-    it "identifies the end of the list" do
+    test "identifies the end of the list" do
       query = """
         query EndOfRebelShipsQuery {
           rebels {
@@ -341,11 +341,4 @@ defmodule StarWars.ConnectionTest do
 
   end
 
-  @tag :pending
-  describe "Ecto Helper" do
-    describe "build_query/2" do
-      it "should set the appropriate limit and offset" do
-      end
-    end
-  end
 end

--- a/test/star_wars/object_identification_test.exs
+++ b/test/star_wars/object_identification_test.exs
@@ -3,7 +3,7 @@ defmodule StarWars.ObjectIdentificationTest do
 
   describe "Star Wars object identification" do
 
-    it "fetches the ID and name of the rebels" do
+    test "fetches the ID and name of the rebels" do
       """
       query RebelsQuery {
         rebels {
@@ -15,7 +15,7 @@ defmodule StarWars.ObjectIdentificationTest do
       |> assert_data(%{"rebels" => %{"id" => "RmFjdGlvbjox", "name" => "Alliance to Restore the Republic"}})
     end
 
-    it "fetches the ID and name of the empire" do
+    test "fetches the ID and name of the empire" do
       """
       query EmpireQuery {
         empire {
@@ -27,7 +27,7 @@ defmodule StarWars.ObjectIdentificationTest do
       |> assert_data(%{"empire" => %{"id" => "RmFjdGlvbjoy", "name" => "Galactic Empire"}})
     end
 
-    it "refetches the empire" do
+    test "refetches the empire" do
       """
       query EmpireRefetchQuery {
         node(id: "RmFjdGlvbjoy") {
@@ -41,7 +41,7 @@ defmodule StarWars.ObjectIdentificationTest do
       |> assert_data(%{"node" => %{"id" => "RmFjdGlvbjoy", "name" => "Galactic Empire"}})
     end
 
-    it "refetches the empire, with nested redundant Node fragment" do
+    test "refetches the empire, with nested redundant Node fragment" do
       """
       query EmpireRefetchQueryWithExtraNodeFragment {
         node(id: "RmFjdGlvbjoy") {
@@ -59,7 +59,7 @@ defmodule StarWars.ObjectIdentificationTest do
       |> assert_data(%{"node" => %{"id" => "RmFjdGlvbjoy", "name" => "Galactic Empire"}})
     end
 
-    it "refetches the X-Wing" do
+    test "refetches the X-Wing" do
       """
       query XWingRefetchQuery {
         node(id: "U2hpcDox") {

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -2,10 +2,7 @@ defmodule Absinthe.Relay.Case do
   defmacro __using__(opts) do
     quote do
       use ExUnit.Case, unquote(opts)
-      import ExUnit.Case, except: [describe: 2]
-      import ExSpec
-
-      Module.put_attribute(__MODULE__, :ex_spec_contexts, [])
+      import ExUnit.Case
     end
   end
 end

--- a/test/support/star_wars/schema.ex
+++ b/test/support/star_wars/schema.ex
@@ -73,7 +73,7 @@ defmodule StarWars.Schema do
   alias StarWars.Database
 
   use Absinthe.Schema
-  use Absinthe.Relay.Schema
+  use Absinthe.Relay.Schema, :classic
 
   alias Absinthe.Relay.Connection
 


### PR DESCRIPTION
- Update deps for absinthe, earmark, ex_doc
- Remove ex_spec
- Convert ExSpec `it` -> `test`
- Restructure tests for modern/classic split
- Clean up warning text