### PR TITLE
Handle middleware error resolutions when resolving node queries.

### DIFF
--- a/lib/absinthe/relay/node.ex
+++ b/lib/absinthe/relay/node.ex
@@ -121,6 +121,9 @@ defmodule Absinthe.Relay.Node do
       _ -> res
     end
   end
+  def resolve_with_global_id(res, _) do
+    res
+  end
   def resolve_with_global_id(res) do
     res
   end


### PR DESCRIPTION
Fixes #83

Previously, if middleware had put an error result into the resolution,
querying a node would result in an error because of a missing pattern
match for Absinthe.Relay.Node.resolve_with_global_id/2. This pull
request introduces a test with a minimal schema/query necessary to
trigger the error, and a simple addition of the missing function head
necessary to restore expected behavior.