### PR TITLE
Support empty cursors with first or last variable present

### DIFF
--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -366,8 +366,9 @@ defmodule Absinthe.Relay.Connection do
     end
   end
 
+  @doc false
   @spec offset_and_limit_for_query(Options.t, from_query_opts) :: {:ok, offset, limit} | {:error, any}
-  defp offset_and_limit_for_query(args, opts) do
+  def offset_and_limit_for_query(args, opts) do
     case limit(args, opts[:max]) do
       {:ok, :forward, limit} ->
         {:ok, offset(args) || 0, limit}

--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -418,9 +418,11 @@ defmodule Absinthe.Relay.Connection do
   If no offset is specified in the pagination arguments, this will return `nil`.
   """
   @spec offset(args :: Options.t) :: offset | nil
+  def offset(%{after: cursor}) when is_nil(cursor), do: nil
   def offset(%{after: cursor}) do
     cursor_to_offset(cursor) + 1
   end
+  def offset(%{before: cursor}) when is_nil(cursor), do: nil
   def offset(%{before: cursor}) do
     max(cursor_to_offset(cursor), 0)
   end

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -201,15 +201,19 @@ defmodule Absinthe.Relay.ConnectionTest do
 
   describe ".offset_and_limit_for_query/2" do
     test "with a cursor" do
-      assert Connection.offset_and_limit_for_query(%{first: 10, after: @offset_cursor_1}, []) == {:ok, 2, 10}
-      assert Connection.offset_and_limit_for_query(%{first: 5, after: @offset_cursor_2}, []) == {:ok, 6, 5}
+      assert Connection.offset_and_limit_for_query(%{first: 10, before: @offset_cursor_1}, []) == {:ok, 1, 10}
+      assert Connection.offset_and_limit_for_query(%{first: 5, before: @offset_cursor_2}, []) == {:ok, 5, 5}
+
       assert Connection.offset_and_limit_for_query(%{last: 10, before: @offset_cursor_1}, []) == {:ok, 0, 10}
       assert Connection.offset_and_limit_for_query(%{last: 5, before: @offset_cursor_2}, []) == {:ok, 0, 5}
     end
 
     test "without a cursor" do
-      assert Connection.offset_and_limit_for_query(%{first: 10, after: nil}, []) == {:ok, 0, 10}
-      assert Connection.offset_and_limit_for_query(%{last: 5, before: nil}, [count: 30]) == {:ok, 25, 5}
+      assert Connection.offset_and_limit_for_query(%{first: 10, before: nil}, []) == {:ok, 0, 10}
+      assert Connection.offset_and_limit_for_query(%{first: 5, after: nil}, []) == {:ok, 0, 5}
+
+      assert Connection.offset_and_limit_for_query(%{last: 10, before: nil}, [count: 30]) == {:ok, 20, 10}
+      assert Connection.offset_and_limit_for_query(%{last: 5, after: nil}, [count: 30]) == {:ok, 25, 5}
     end
   end
 end

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -4,6 +4,8 @@ defmodule Absinthe.Relay.ConnectionTest do
   alias Absinthe.Relay.Connection
 
   @jack_global_id Base.encode64("Person:jack")
+  @offset_cursor_1 Base.encode64("arrayconnection:1")
+  @offset_cursor_2 Base.encode64("arrayconnection:5")
 
   defmodule CustomConnectionAndEdgeFieldsSchema do
     use Absinthe.Schema
@@ -194,6 +196,20 @@ defmodule Absinthe.Relay.ConnectionTest do
   describe ".from_slice/2" do
     test "when the offset is nil test will not do arithmetic on nil" do
       Connection.from_slice([%{foo: :bar}], nil)
+    end
+  end
+
+  describe ".offset_and_limit_for_query/2" do
+    test "with a cursor" do
+      assert Connection.offset_and_limit_for_query(%{first: 10, after: @offset_cursor_1}, []) == {:ok, 2, 10}
+      assert Connection.offset_and_limit_for_query(%{first: 5, after: @offset_cursor_2}, []) == {:ok, 6, 5}
+      assert Connection.offset_and_limit_for_query(%{last: 10, before: @offset_cursor_1}, []) == {:ok, 0, 10}
+      assert Connection.offset_and_limit_for_query(%{last: 5, before: @offset_cursor_2}, []) == {:ok, 0, 5}
+    end
+
+    test "without a cursor" do
+      assert Connection.offset_and_limit_for_query(%{first: 10, after: nil}, []) == {:ok, 0, 10}
+      assert Connection.offset_and_limit_for_query(%{last: 5, before: nil}, [count: 30]) == {:ok, 25, 5}
     end
   end
 end

--- a/test/lib/absinthe/relay/node_test.exs
+++ b/test/lib/absinthe/relay/node_test.exs
@@ -88,7 +88,7 @@ defmodule Absinthe.Relay.NodeTest do
 
   describe "global_id_resolver" do
 
-    it "returns a function that returns an error when a global id can't be resolved" do
+    test "returns a function that returns an error when a global id can't be resolved" do
       fun = fn ->
         resolver = Absinthe.Relay.Node.global_id_resolver(:other_foo, nil)
         resolver.(%{}, %{schema: Schema, source: %{}})


### PR DESCRIPTION
Support empty cursors even if first or last is present.