### PR TITLE
Support null value parsing in ParseIDs middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 Status: RC
 
-- Bug Fix: Support `null` values for `before` and `after` pagination arguments
+- Feature: Support `null` values in `ParseIDs` middleware (passed through as `nil` args)
+- Bug Fix: Support `null` values for `before` and `after` pagination arguments (expected by Relay Modern)
 
 ## 1.3.6
 - Type Spec Fix: Relax type constraints around `Connection.from_query`

--- a/lib/absinthe/relay/node.ex
+++ b/lib/absinthe/relay/node.ex
@@ -130,6 +130,13 @@ defmodule Absinthe.Relay.Node do
 
   ## Examples
 
+  For `nil`, pass-through:
+
+  ```
+  iex> from_global_id(nil, Schema)
+  {:ok, nil}
+  ```
+
   For a valid, existing type in `Schema`:
 
   ```
@@ -158,7 +165,11 @@ defmodule Absinthe.Relay.Node do
   {:error, "Type `Item' is not a valid node type"}
   ```
   """
+  @spec from_global_id(nil, atom) :: {:ok, nil}
   @spec from_global_id(binary, atom) :: {:ok, %{type: atom, id: binary}} | {:error, binary}
+  def from_global_id(nil, _schema) do
+    {:ok, nil}
+  end
   def from_global_id(global_id, schema) do
     case Base.decode64(global_id) do
       {:ok, decoded} ->

--- a/lib/absinthe/relay/node/parse_ids.ex
+++ b/lib/absinthe/relay/node/parse_ids.ex
@@ -13,6 +13,9 @@ defmodule Absinthe.Relay.Node.ParseIDs do
     argument map will be replaced by a map with the node ID specific to your
     application as `:id` and the parsed node type as `:type`.
 
+  If a GraphQL `null` value for an ID is found, it will be passed through as
+  `nil` in either case, since no type can be associated with the value.
+
   ## Examples
 
   Parse a node (global) ID argument `:item_id` as an `:item` type. This replaces
@@ -177,11 +180,15 @@ defmodule Absinthe.Relay.Node.ParseIDs do
 
   Note that using these two different forms will result in different argument
   values being passed for `:item_id` (the former, as a `binary`, the latter
-  as a `map`). See the module documentation for more details.
+  as a `map`).
+
+  In the event that the ID is a `null`, it will be passed-through as `nil`.
+
+  See the module documentation for more details.
   """
   @type rules :: [{atom, atom | [atom]}] | %{atom => atom | [atom]}
 
-  @type simple_result :: binary
+  @type simple_result :: nil | binary
   @type full_result :: %{type: atom, id: simple_result}
   @type result :: full_result | simple_result
 
@@ -303,7 +310,11 @@ defmodule Absinthe.Relay.Node.ParseIDs do
   end
 
 
+  @spec check_result(nil, Rule.t, Absinthe.Resolution.t) :: {:ok, nil}
   @spec check_result(full_result, Rule.t, Absinthe.Resolution.t) :: {:ok, full_result} | {:error, String.t}
+  defp check_result(nil, _rule, _resolution) do
+    {:ok, nil}
+  end
   defp check_result(%{type: type} = result, %Rule{expected_types: types} = rule, resolution) do
     if type in types do
       {:ok, result}

--- a/lib/absinthe/relay/node/parse_ids/rule.ex
+++ b/lib/absinthe/relay/node/parse_ids/rule.ex
@@ -15,7 +15,9 @@ defmodule Absinthe.Relay.Node.ParseIDs.Rule do
     output_mode: :full | :simple,
   }
 
+  @spec output(t, nil) :: nil
   @spec output(t, ParseIDs.result) :: ParseIDs.full_result | ParseIDs.simple_result
+  def output(_rule, nil), do: nil
   def output(%{output_mode: :full}, result), do: result
   def output(%{output_mode: :simple}, %{id: id}), do: id
 

--- a/test/lib/absinthe/relay/node/parse_ids_test.exs
+++ b/test/lib/absinthe/relay/node/parse_ids_test.exs
@@ -66,7 +66,7 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
     end
 
     input_object :child_input do
-      field :id, non_null(:id)
+      field :id, :id
     end
 
     query do
@@ -128,6 +128,9 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
     defp resolve_foo(%{foo_id: id}, _) do
       {:ok, Map.get(@foos, id)}
     end
+    defp resolve_foo(%{foobar_id: nil}, _) do
+      {:ok, nil}
+    end
     defp resolve_foo(%{foobar_id: %{id: id, type: :foo}}, _) do
       {:ok, Map.get(@foos, id)}
     end
@@ -138,7 +141,30 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
     end
 
     defp resolve_parent(args, _) do
-      {:ok, args}
+      {:ok, args |> to_parent_output}
+    end
+
+    # This is just a utility that converts the input value into the
+    # expected output value (which has non-null constraints).
+    #
+    # It doesn't have any value outside these tests!
+    #
+    defp to_parent_output(%{id: nil}) do
+      nil
+    end
+    defp to_parent_output(values) when is_list(values) do
+      for value <- values do
+        value
+        |> to_parent_output
+      end
+    end
+    defp to_parent_output(%{} = args) do
+      for {key, value} <- args, into: %{} do
+        {key, value |> to_parent_output}
+      end
+    end
+    defp to_parent_output(value) do
+      value
     end
 
     @update_parent_ids {
@@ -166,87 +192,176 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
   @foo1_id Base.encode64("Foo:1")
   @foo2_id Base.encode64("Foo:2")
 
-  it "parses one id correctly" do
-    result =
-      """
-      {
-        foo(fooId: "#{@foo1_id}") {
-          id
-          name
-        }
-      }
-      """
-      |> Absinthe.run(Schema)
-    assert {:ok, %{data: %{"foo" => %{"name" => "Foo 1", "id" => @foo1_id}}}} == result
-  end
+  context "parses one id" do
 
-  it "parses a list of ids correctly" do
-    result =
-      """
-      {
-        foos(fooIds: ["#{@foo1_id}", "#{@foo2_id}"]) { id name }
-      }
-      """
-      |> Absinthe.run(Schema)
-    assert {:ok,
-      %{
-        data: %{
-          "foos" => [
-            %{"name" => "Foo 1", "id" => @foo1_id},
-            %{"name" => "Foo 2", "id" => @foo2_id}
-          ]
-        }
-      }
-    } == result
-  end
-
-  it "parses an id into one of multiple node types" do
-    result =
-      """
-      {
-        foo(foobarId: "#{@foo1_id}") { id name }
-      }
-      """
-      |> Absinthe.run(Schema)
-    assert {:ok, %{data: %{"foo" => %{"name" => "Foo 1", "id" => @foo1_id}}}} == result
-  end
-
-  @tag :focus
-  it "parses nested ids" do
-    encoded_parent_id = Base.encode64("Parent:1")
-    encoded_child1_id = Base.encode64("Child:1")
-    encoded_child2_id = Base.encode64("Child:1")
-    result =
-      """
-      mutation Foobar {
-        updateParent(input: {
-          clientMutationId: "abc",
-          parent: {
-            id: "#{encoded_parent_id}",
-            children: [{ id: "#{encoded_child1_id}"}, {id: "#{encoded_child2_id}"}],
-            child: { id: "#{encoded_child2_id}"}
-          }
-        }) {
-          parent {
+    it "succeeds with a non-null value" do
+      result =
+        """
+        {
+          foo(fooId: "#{@foo1_id}") {
             id
-            children { id }
-            child { id }
-            }
+            name
           }
-      }
-      """
-      |> Absinthe.run(Schema)
+        }
+        """
+        |> Absinthe.run(Schema)
+      assert {:ok, %{data: %{"foo" => %{"name" => "Foo 1", "id" => @foo1_id}}}} == result
+    end
 
-    expected_parent_data = %{
-      "parent" => %{
-        "id" => encoded_parent_id, # The output re-converts everything to global_ids.
-        "children" => [%{"id" => encoded_child1_id}, %{"id" => encoded_child2_id}],
-        "child" => %{
-          "id" => encoded_child2_id
+    it "succeeds with a null value" do
+      result =
+        """
+        {
+          foo(fooId: null) {
+            id
+            name
+          }
+        }
+        """
+        |> Absinthe.run(Schema)
+      assert {:ok, %{data: %{"foo" => nil}}} == result
+    end
+
+  end
+
+  context "parses a list of ids" do
+
+    it "succeeds with a non-null value" do
+      result =
+        """
+        {
+          foos(fooIds: ["#{@foo1_id}", "#{@foo2_id}"]) { id name }
+        }
+        """
+        |> Absinthe.run(Schema)
+      assert {:ok,
+        %{
+          data: %{
+            "foos" => [
+              %{"name" => "Foo 1", "id" => @foo1_id},
+              %{"name" => "Foo 2", "id" => @foo2_id}
+            ]
+          }
+        }
+      } == result
+    end
+
+    it "succeeds with a null value" do
+      result =
+        """
+        {
+          foos(fooIds: [null, "#{@foo2_id}"]) { id name }
+        }
+        """
+        |> Absinthe.run(Schema)
+      assert {:ok,
+              %{
+                data: %{
+                  "foos" => [
+                    nil,
+                    %{"name" => "Foo 2", "id" => @foo2_id}
+                  ]
+                }
+              }
+      } == result
+    end
+
+  end
+
+  context "parsing an id into one of multiple node types" do
+    it "parses an non-null id into one of multiple node types" do
+      result =
+        """
+        {
+          foo(foobarId: "#{@foo1_id}") { id name }
+        }
+        """
+        |> Absinthe.run(Schema)
+      assert {:ok, %{data: %{"foo" => %{"name" => "Foo 1", "id" => @foo1_id}}}} == result
+    end
+    it "parses null" do
+      result =
+        """
+        {
+          foo(foobarId: null) { id name }
+        }
+        """
+        |> Absinthe.run(Schema)
+      assert {:ok, %{data: %{"foo" => nil}}} == result
+    end
+  end
+
+  context "parsing nested ids" do
+    it "works with non-null values" do
+      encoded_parent_id = Base.encode64("Parent:1")
+      encoded_child1_id = Base.encode64("Child:1")
+      encoded_child2_id = Base.encode64("Child:1")
+      result =
+        """
+        mutation Foobar {
+          updateParent(input: {
+            clientMutationId: "abc",
+            parent: {
+              id: "#{encoded_parent_id}",
+              children: [{ id: "#{encoded_child1_id}"}, {id: "#{encoded_child2_id}"}],
+              child: { id: "#{encoded_child2_id}"}
+            }
+          }) {
+            parent {
+              id
+              children { id }
+              child { id }
+              }
+            }
+        }
+        """
+        |> Absinthe.run(Schema)
+
+      expected_parent_data = %{
+        "parent" => %{
+          "id" => encoded_parent_id, # The output re-converts everything to global_ids.
+          "children" => [%{"id" => encoded_child1_id}, %{"id" => encoded_child2_id}],
+          "child" => %{
+            "id" => encoded_child2_id
+          }
         }
       }
-    }
-    assert {:ok, %{data: %{"updateParent" => expected_parent_data}}} == result
+      assert {:ok, %{data: %{"updateParent" => expected_parent_data}}} == result
+    end
+    it "works with null leaf values" do
+      encoded_parent_id = Base.encode64("Parent:1")
+      encoded_child1_id = Base.encode64("Child:1")
+      result =
+        """
+        mutation Foobar {
+          updateParent(input: {
+            clientMutationId: "abc",
+            parent: {
+              id: "#{encoded_parent_id}",
+              children: [{ id: "#{encoded_child1_id}" }, { id: null }],
+              child: { id: null }
+            }
+          }) {
+            parent {
+              id
+              children { id }
+              child { id }
+              }
+            }
+        }
+        """
+        |> Absinthe.run(Schema)
+
+      expected_parent_data = %{
+        "parent" => %{
+          "id" => encoded_parent_id, # The output re-converts everything to global_ids.
+          "children" => [%{"id" => encoded_child1_id}, nil],
+          "child" => nil
+        }
+      }
+      assert {:ok, %{data: %{"updateParent" => expected_parent_data}}} == result
+    end
+
   end
 
   it "parses incorrect nested ids" do
@@ -311,7 +426,7 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
           clientMutationId: "abc",
           parent: {
             id: "#{encoded_parent_id}",
-            children: [{ id: "#{encoded_child1_id}"}, {id: "#{encoded_child2_id}"}],
+            children: [{ id: "#{encoded_child1_id}"}, {id: "#{encoded_child2_id}"}, {id: null}],
             child: { id: "#{encoded_child2_id}"}
           }
         }) {
@@ -328,7 +443,7 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
     expected_parent_data = %{
       "parent" => %{
         "id" => encoded_parent_id, # The output re-converts everything to global_ids.
-        "children" => [%{"id" => encoded_child1_id}, %{"id" => encoded_child2_id}],
+        "children" => [%{"id" => encoded_child1_id}, %{"id" => encoded_child2_id}, nil],
         "child" => %{
           "id" => encoded_child2_id
         }


### PR DESCRIPTION
This PR adds support for parsing `null` values as input for the `Absinthe.Relay.Node.ParseIDs` middleware input.

When a `null` is encountered, it is passed through as a `nil` argument value. Note this is also true when multiple possible types are valid for the argument—since no type can be identified, no wrapping `%{type: _, id: nil}` is necessary. Just match for bare `nil` values in your resolvers.

Resolves #82.