### PR TITLE
Customize the node resolver

### DIFF
--- a/lib/absinthe/relay/connection/notation.ex
+++ b/lib/absinthe/relay/connection/notation.ex
@@ -239,13 +239,14 @@ defmodule Absinthe.Relay.Connection.Notation do
     end
   end
 
-  defp defines_field?(nil, _), do: false
-  defp defines_field?({:__block__, [], fields}, field_name), do: defines_field?(fields, field_name)
-  defp defines_field?([{:field, _, [field_name | _]} | _], field_name), do: true
-  defp defines_field?([_ | fields], field_name), do: defines_field?(fields, field_name)
-  defp defines_field?({:field, _, [field_name | _]}, field_name), do: true
-  defp defines_field?({_, _, _}, _), do: false
-  defp defines_field?([], _), do: false
+
+  defp defines_field?(ast, field_name) do
+    {_, defined?} = Macro.prewalk(ast, false, fn
+      {:field, _, [^field_name | _]}, _ = node -> {node, true}
+      expr, acc -> {expr, acc}
+    end)
+    defined?
+  end
 
   # Forward pagination arguments.
   #

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -25,6 +25,7 @@ defmodule Absinthe.Relay.ConnectionTest do
     node object :pet do
       field :name, :string
       field :age, :string
+      field :custom_resolver, :boolean
     end
 
     connection node_type: :pet do
@@ -40,6 +41,11 @@ defmodule Absinthe.Relay.ConnectionTest do
             _, %{source: edge} ->
               {:ok, edge.node.name |> String.reverse}
           end
+        end
+
+        field :node, :pet do
+          resolve fn _, %{source: source} ->
+            {:ok, Map.put(source.node, :custom_resolver, true)} end
         end
       end
     end
@@ -123,6 +129,7 @@ defmodule Absinthe.Relay.ConnectionTest do
                   nodeNameBackwards
                   node {
                     name
+                    custom_resolver
                   }
                 }
               }
@@ -140,7 +147,7 @@ defmodule Absinthe.Relay.ConnectionTest do
         }
       """ |> Absinthe.run(CustomConnectionAndEdgeFieldsSchema, variables: %{"personId" => @jack_global_id})
       assert {:ok, %{data: %{"node" => %{
-                              "pets" => %{"twiceEdgesCount" => 2, "edges" => [%{"nodeNameBackwards" => "ajnevS", "node" => %{"name" => "Svenja"}}]},
+                              "pets" => %{"twiceEdgesCount" => 2, "edges" => [%{"nodeNameBackwards" => "ajnevS", "node" => %{"name" => "Svenja", "custom_resolver" => true}}]},
                               "favoritePets" => %{"favTwiceEdgesCount" => 2, "edges" => [%{"favNodeNameBackwards" => "kcoJ", "node" => %{"name" => "Jock"}}]}}
                             }}} == result
     end


### PR DESCRIPTION
This PR allows you to override the `:node` resolver for an Relay connection.

This is useful in a number of scenarios, but particularly when working with a data source (such as NoSQL) that represents relationships as arrays of foreign keys that you still want to page over.

My previous solution was to simply use `Connection.from_list` and modify the node edge in the resolver, but that's hacky and doesn't support the niceties of the batch middleware out of the box.

This PR enables overriding `:node` and inserts a default implementation if none is provided. Unfortunately, the only way I managed to figure out how was by parsing the provided block and looking for the specified field, but it seems to work well enough.

Tried to update the docs as best as I could as well!