### PR TITLE
Enhancements to Connection builder functions to allow inclusion of edge data

### DIFF
--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -244,6 +244,13 @@ defmodule Absinthe.Relay.Connection do
   end
   ```
 
+  Be aware that if you pass `:node` in the arguments
+  provided in the second element of the edge tuple you will override
+  the node provided in the first element.
+
+  Similarly, if you provide a `:cursor` argument then this will override
+  the internally generated cursor. This may or may not be desirable.
+
   ## Schema Macros
 
   For more details on connection-related macros, see

--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -499,7 +499,7 @@ defmodule Absinthe.Relay.Connection do
           end
       end
     end
-  endp
+  end
 
   @doc """
   Same as `limit/1` with user provided upper bound.

--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -258,6 +258,7 @@ defmodule Absinthe.Relay.Connection do
   """
 
   alias Absinthe.Relay.Connection.Options
+  require Logger
 
   @cursor_prefix "arrayconnection:"
 
@@ -532,7 +533,15 @@ defmodule Absinthe.Relay.Connection do
   end
 
   defp build_edge({item, args}, cursor) do
-    Enum.into(args, build_edge(item, cursor))
+    args
+    |> Enum.flat_map(fn
+      {:node, _} ->
+        Logger.warn("Ignoring additional node provided on edge")
+        []
+      {key, val} ->
+        [{key, val}]
+    end)
+    |> Enum.into(build_edge(item, cursor))
   end
 
   defp build_edge(item, cursor) do

--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -578,8 +578,8 @@ defmodule Absinthe.Relay.Connection do
   defp build_edge({item, args}, cursor) do
     args
     |> Enum.flat_map(fn
-      {:node, _} ->
-        Logger.warn("Ignoring additional node provided on edge")
+      {key, _} when key in [:cursor, :node] ->
+        Logger.warn("Ignoring additional #{key} provided on edge (overriding is not allowed)")
         []
       {key, val} ->
         [{key, val}]

--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -245,10 +245,10 @@ defmodule Absinthe.Relay.Connection do
   on the edge itself via `from_query`:
 
   ```
-  # In a PostResolver module
+  # In a UserResolver module
   alias Absinthe.Relay
 
-  def list(args, %{context: %{current_user: user}}) do
+  def list_teams(args, %{context: %{current_user: user}}) do
     TeamAssignment
     |> from
     |> where([a], a.user_id == ^user.id)

--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -207,7 +207,7 @@ defmodule Absinthe.Relay.Connection do
   a connection produced from these items.
 
   ### Supplying Edge Information
-  
+
   In some cases you may wish to supply extra information about the edge
   so that it can be used in the schema. For example:
 
@@ -231,7 +231,7 @@ defmodule Absinthe.Relay.Connection do
   ]
   |> Connection.from_list(args)
   ```
-  
+
   This is useful when using ecto to include relationship information
   on the edge itself via `from_query`:
 
@@ -249,11 +249,10 @@ defmodule Absinthe.Relay.Connection do
   end
   ```
 
-  Be aware that if you pass `:node` in the arguments
-  provided in the second element of the edge tuple you will override
-  the node provided in the first element.
+  Be aware that if you pass `:node` in the arguments provided as the second
+  element of the edge tuple, that value will be ignored and a warning logged.
 
-  Similarly, if you provide a `:cursor` argument then this will override
+  If you provide a `:cursor` argument, then your value will override
   the internally generated cursor. This may or may not be desirable.
 
   ## Schema Macros
@@ -500,7 +499,7 @@ defmodule Absinthe.Relay.Connection do
           end
       end
     end
-  end
+  endp
 
   @doc """
   Same as `limit/1` with user provided upper bound.

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -337,7 +337,7 @@ defmodule Absinthe.Relay.ConnectionTest do
 
     test " allows querying arbitrary edge fields" do
       result = """
-        query TeamAndUsers($teamId: ID!) {
+        query TeamAndRepos($teamId: ID!) {
           node(id: $teamId) {
             ... on Team {
               repos(first: 2) {

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -50,7 +50,7 @@ defmodule Absinthe.Relay.ConnectionTest do
 
     connection node_type: :user do
       edge do
-        field :predicate, :string
+        field :role, :string
       end
     end
 
@@ -68,7 +68,7 @@ defmodule Absinthe.Relay.ConnectionTest do
           resolve_args, %{source: team} ->
             Absinthe.Relay.Connection.from_list(
               Enum.map(team.users, fn {role, id} ->
-                {role, Map.get(@users, id)}
+                {Map.get(@users, id), role: role}
               end),
               resolve_args
             )
@@ -80,7 +80,7 @@ defmodule Absinthe.Relay.ConnectionTest do
           resolve_args, %{source: team} ->
             Absinthe.Relay.Connection.from_list(
               Enum.map(team.repos, fn {attrs, id} ->
-                Map.merge(attrs, %{node: Map.get(@repos, id)})
+                {Map.get(@repos, id), attrs}
               end),
               resolve_args
             )
@@ -312,7 +312,7 @@ defmodule Absinthe.Relay.ConnectionTest do
             ... on Team {
               users(first: 1) {
                 edges {
-                  predicate
+                  role
                   node {
                     email
                   }
@@ -327,7 +327,7 @@ defmodule Absinthe.Relay.ConnectionTest do
           "node" => %{
             "users" => %{
               "edges" => [
-                %{"predicate" => "owner", "node" => %{"email" => "homer@sector7g.burnsnuclear.com"}}
+                %{"role" => "owner", "node" => %{"email" => "homer@sector7g.burnsnuclear.com"}}
               ]
             },
           }

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -1,5 +1,6 @@
 defmodule Absinthe.Relay.ConnectionTest do
   use Absinthe.Relay.Case, async: true
+  import ExUnit.CaptureLog
 
   alias Absinthe.Relay.Connection
 
@@ -365,9 +366,25 @@ defmodule Absinthe.Relay.ConnectionTest do
         }
       }} == result
     end
-
   end
 
+  describe "when provided with a node as an edge arg" do
+    setup do
+      [record: {%{name: "Dan"}, %{role: "contributor", node: :bad}}]
+    end
+
+    test "it will ignore the additional node", %{record: record} do
+      {:ok, %{edges: [%{node: node} | _]}} = Connection.from_list([record], %{first: 1})
+
+      assert node == %{name: "Dan"}
+    end
+
+    test "it log a warning", %{record: record} do
+      assert capture_log(fn ->
+        Connection.from_list([record], %{first: 1})
+      end) =~ "Ignoring additional node provided on edge"
+    end
+  end
 
   describe ".from_slice/2" do
     test "when the offset is nil test will not do arithmetic on nil" do

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -39,8 +39,8 @@ defmodule Absinthe.Relay.ConnectionTest do
     }
 
     @repos %{
-      "1" => %{id: "1", name: "bowlarama"}, 
-      "2" => %{id: "2", name: "krustys"}, 
+      "1" => %{id: "1", name: "bowlarama"},
+      "2" => %{id: "2", name: "krustys"},
       "3" => %{id: "3", name: "leftorium"},
     }
 

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -433,6 +433,25 @@ defmodule Absinthe.Relay.ConnectionTest do
     end
   end
 
+  describe "when provided with a cursor as an edge arg" do
+    setup do
+      [record: {%{name: "Dan"}, %{role: "contributor", cursor: :bad}}]
+    end
+
+    test "it will ignore the additional cursor", %{record: record} do
+      capture_log(fn ->
+        {:ok, %{edges: [%{cursor: cursor} | _]}} = Connection.from_list([record], %{first: 1})
+        assert cursor == "YXJyYXljb25uZWN0aW9uOjA="
+      end)
+    end
+    test "it will log a warning", %{record: record} do
+      assert capture_log(fn ->
+        Connection.from_list([record], %{first: 1})
+      end) =~ "Ignoring additional cursor provided on edge"
+    end
+  end
+
+
   describe ".from_slice/2" do
     test "when the offset is nil test will not do arithmetic on nil" do
       Connection.from_slice([%{foo: :bar}], nil)

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -421,12 +421,12 @@ defmodule Absinthe.Relay.ConnectionTest do
     end
 
     test "it will ignore the additional node", %{record: record} do
-      {:ok, %{edges: [%{node: node} | _]}} = Connection.from_list([record], %{first: 1})
-
-      assert node == %{name: "Dan"}
+      capture_log(fn ->
+        {:ok, %{edges: [%{node: node} | _]}} = Connection.from_list([record], %{first: 1})
+        assert node == %{name: "Dan"}
+      end)
     end
-
-    test "it log a warning", %{record: record} do
+    test "it will log a warning", %{record: record} do
       assert capture_log(fn ->
         Connection.from_list([record], %{first: 1})
       end) =~ "Ignoring additional node provided on edge"


### PR DESCRIPTION
In the [spec](https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types.Fields) for connections described by Facebook, edges can be defined with arbitrary fields.

This pull request provides additional capabilities to the `Absinthe.Relay.Connection` module, specifically via changes to the private `build_cursors` functions to allow resolving of edge data.

For example:

```graphql
{
  team(id: 1) {
    users(first: 5) {
      edges {
        role
        node {
          email
        }
      }
    }
  }
}
```

While Absinthe Relay does support defining fields on edges, these fields can only be resolved based on data already provided on the node. In many cases it may be useful to have edge data resolved from a database query or other service.