### PR TITLE
Invalid cursor error handling

### DIFF
--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -271,13 +271,14 @@ defmodule Absinthe.Relay.Connection do
   """
   @spec from_list(data :: list, args :: Option.t) :: {:ok, t} | {:error, any}
   def from_list(data, args, opts \\ []) do
-    with {:ok, direction, limit} <- limit(args, opts[:max]) do
+    with {:ok, direction, limit} <- limit(args, opts[:max]),
+         {:ok, offset} <- offset(args) do
       count = length(data)
       {offset, limit} = case direction do
         :forward ->
-          {offset(args) || 0, limit}
+          {offset || 0, limit}
         :backward ->
-          end_offset = offset(args) || count
+          end_offset = offset || count
           start_offset = max(end_offset - limit, 0)
           limit = if start_offset == 0, do: end_offset, else: limit
           {start_offset, limit}
@@ -407,19 +408,19 @@ defmodule Absinthe.Relay.Connection do
   @doc false
   @spec offset_and_limit_for_query(Options.t, from_query_opts) :: {:ok, offset, limit} | {:error, any}
   def offset_and_limit_for_query(args, opts) do
-    case limit(args, opts[:max]) do
-      {:ok, :forward, limit} ->
-        {:ok, offset(args) || 0, limit}
+    with {:ok, direction, limit} <- limit(args, opts[:max]),
+         {:ok, offset} <- offset(args) do
+      case direction do
+        :forward ->
+          {:ok, offset || 0, limit}
 
-      {:ok, :backward, limit} ->
-        case {offset(args), opts[:count]} do
-          {nil, nil} -> {:error, "You must supply a count (total number of records) option if using `last` without `before`"}
-          {nil, value} -> {:ok, max(value - limit, 0), limit}
-          {value, _} -> {:ok, max(value - limit, 0), limit}
-        end
-
-      {:error, reason} ->
-        {:error, reason}
+        :backward ->
+          case {offset, opts[:count]} do
+            {nil, nil} -> {:error, "You must supply a count (total number of records) option if using `last` without `before`"}
+            {nil, value} -> {:ok, max(value - limit, 0), limit}
+            {value, _} -> {:ok, max(value - limit, 0), limit}
+          end
+      end
     end
   end
 
@@ -456,14 +457,14 @@ defmodule Absinthe.Relay.Connection do
 
   If no offset is specified in the pagination arguments, this will return `nil`.
   """
-  @spec offset(args :: Options.t) :: offset | nil
+  @spec offset(args :: Options.t) :: {:ok, offset | nil} | {:error, any}
   def offset(%{after: cursor}) when not is_nil(cursor) do
-    cursor_to_offset(cursor) + 1
+    with {:ok, offset} <- cursor_to_offset(cursor), do: {:ok, offset + 1}
   end
   def offset(%{before: cursor}) when not is_nil(cursor) do
-    max(cursor_to_offset(cursor), 0)
+    with {:ok, offset} <- cursor_to_offset(cursor), do: {:ok, max(offset, 0)}
   end
-  def offset(_), do: nil
+  def offset(_), do: {:ok, nil}
 
   defp build_cursors([], _offset), do: {[], nil, nil}
   defp build_cursors([item | items], offset) do
@@ -504,7 +505,9 @@ defmodule Absinthe.Relay.Connection do
   def cursor_to_offset(cursor) do
     with {:ok, @cursor_prefix <> raw} <- Base.decode64(cursor),
          {parsed, _} <- Integer.parse(raw) do
-      parsed
+      {:ok, parsed}
+    else
+      :error -> {:error, "Invalid cursor"}
     end
   end
 

--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -459,10 +459,20 @@ defmodule Absinthe.Relay.Connection do
   """
   @spec offset(args :: Options.t) :: {:ok, offset | nil} | {:error, any}
   def offset(%{after: cursor}) when not is_nil(cursor) do
-    with {:ok, offset} <- cursor_to_offset(cursor), do: {:ok, offset + 1}
+    with {:ok, offset} <- cursor_to_offset(cursor) do
+      {:ok, offset + 1}
+    else
+      {:error, _} ->
+        {:error, "Invalid cursor provided as `after` argument"}
+    end
   end
   def offset(%{before: cursor}) when not is_nil(cursor) do
-    with {:ok, offset} <- cursor_to_offset(cursor), do: {:ok, max(offset, 0)}
+    with {:ok, offset} <- cursor_to_offset(cursor) do
+      {:ok, max(offset, 0)}
+    else
+      {:error, _} ->
+        {:error, "Invalid cursor provided as `before` argument"}
+    end
   end
   def offset(_), do: {:ok, nil}
 

--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -507,7 +507,7 @@ defmodule Absinthe.Relay.Connection do
          {parsed, _} <- Integer.parse(raw) do
       {:ok, parsed}
     else
-      :error -> {:error, "Invalid cursor"}
+      _ -> {:error, "Invalid cursor"}
     end
   end
 

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -227,12 +227,11 @@ defmodule Absinthe.Relay.ConnectionTest do
     end
 
     test "with an invalid cursor" do
-      assert Connection.offset_and_limit_for_query(%{first: 10, before: @invalid_cursor_1}, [])
-      == {:error, "Invalid cursor"}
-      assert Connection.offset_and_limit_for_query(%{first: 10, before: @invalid_cursor_2}, [])
-      == {:error, "Invalid cursor"}
-      assert Connection.offset_and_limit_for_query(%{first: 10, before: @invalid_cursor_3}, [])
-      == {:error, "Invalid cursor"}
+      assert Connection.offset_and_limit_for_query(%{first: 10, before: @invalid_cursor_1}, []) == {:error, "Invalid cursor provided as `before` argument"}
+      assert Connection.offset_and_limit_for_query(%{first: 10, before: @invalid_cursor_2}, []) == {:error, "Invalid cursor provided as `before` argument"}
+      assert Connection.offset_and_limit_for_query(%{first: 10, before: @invalid_cursor_3}, []) == {:error, "Invalid cursor provided as `before` argument"}
+
+      assert Connection.offset_and_limit_for_query(%{last: 5, after: @invalid_cursor_1}, [count: 30]) == {:error, "Invalid cursor provided as `after` argument"}
     end
   end
 end

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -222,5 +222,10 @@ defmodule Absinthe.Relay.ConnectionTest do
       assert Connection.offset_and_limit_for_query(%{last: 10, before: nil}, [count: 30]) == {:ok, 20, 10}
       assert Connection.offset_and_limit_for_query(%{last: 5, after: nil}, [count: 30]) == {:ok, 25, 5}
     end
+
+    test "with an invalid cursor" do
+      assert Connection.offset_and_limit_for_query(%{first: 10, before: "bad_cursor"}, [])
+      == {:error, "Invalid cursor"}
+    end
   end
 end

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -6,6 +6,9 @@ defmodule Absinthe.Relay.ConnectionTest do
   @jack_global_id Base.encode64("Person:jack")
   @offset_cursor_1 Base.encode64("arrayconnection:1")
   @offset_cursor_2 Base.encode64("arrayconnection:5")
+  @invalid_cursor_1 Base.encode64("not_arrayconnection:5")
+  @invalid_cursor_2 Base.encode64("arrayconnection:five")
+  @invalid_cursor_3 Base.encode64("not a cursor at all")
 
   defmodule CustomConnectionAndEdgeFieldsSchema do
     use Absinthe.Schema
@@ -224,7 +227,11 @@ defmodule Absinthe.Relay.ConnectionTest do
     end
 
     test "with an invalid cursor" do
-      assert Connection.offset_and_limit_for_query(%{first: 10, before: "bad_cursor"}, [])
+      assert Connection.offset_and_limit_for_query(%{first: 10, before: @invalid_cursor_1}, [])
+      == {:error, "Invalid cursor"}
+      assert Connection.offset_and_limit_for_query(%{first: 10, before: @invalid_cursor_2}, [])
+      == {:error, "Invalid cursor"}
+      assert Connection.offset_and_limit_for_query(%{first: 10, before: @invalid_cursor_3}, [])
       == {:error, "Invalid cursor"}
     end
   end


### PR DESCRIPTION
Previously a query with an invalid cursor (one which either wasn't valid base64, didn't have the correct prefix, or didn't contain a valid integer) would cause a crash. This change makes it return an error consistent with other behaviour on bad client input.