### PR TITLE
Updates logic for hasPreviousPage/hasNextPage based on latest Relay spec

### DIFF
--- a/test/lib/absinthe/relay/pagination_test.exs
+++ b/test/lib/absinthe/relay/pagination_test.exs
@@ -104,7 +104,7 @@ defmodule Absinthe.Relay.PaginationTest do
       "page_info" => %{
         "start_cursor" => ^cursor2,
         "end_cursor" => cursor4,
-        "has_previous_page" => false,
+        "has_previous_page" => true,
         "has_next_page" => true,
       },
       "edges" => [
@@ -130,7 +130,7 @@ defmodule Absinthe.Relay.PaginationTest do
       "page_info" => %{
         "start_cursor" => cursor5,
         "end_cursor" => cursor9,
-        "has_previous_page" => false,
+        "has_previous_page" => true,
         "has_next_page" => false,
       },
       "edges" => [
@@ -163,7 +163,7 @@ defmodule Absinthe.Relay.PaginationTest do
       "page_info" => %{
         "start_cursor" => nil,
         "end_cursor" => nil,
-        "has_previous_page" => false,
+        "has_previous_page" => true,
         "has_next_page" => false,
       },
       "edges" => [],
@@ -241,7 +241,7 @@ defmodule Absinthe.Relay.PaginationTest do
         "start_cursor" => cursor5,
         "end_cursor" => ^cursor7,
         "has_previous_page" => true,
-        "has_next_page" => false,
+        "has_next_page" => true,
       },
       "edges" => [
         %{
@@ -267,7 +267,7 @@ defmodule Absinthe.Relay.PaginationTest do
         "start_cursor" => cursor0,
         "end_cursor" => cursor4,
         "has_previous_page" => false,
-        "has_next_page" => false,
+        "has_next_page" => true,
       },
       "edges" => [
         %{
@@ -300,7 +300,7 @@ defmodule Absinthe.Relay.PaginationTest do
         "start_cursor" => nil,
         "end_cursor" => nil,
         "has_previous_page" => false,
-        "has_next_page" => false,
+        "has_next_page" => true,
       },
       "edges" => [],
     }} = result

--- a/test/star_wars/connection_test.exs
+++ b/test/star_wars/connection_test.exs
@@ -108,7 +108,7 @@ defmodule StarWars.ConnectionTest do
             ],
             "pageInfo" => %{
               "hasPreviousPage" => false,
-              "hasNextPage" => false,
+              "hasNextPage" => true,
             }
           },
         }


### PR DESCRIPTION
Fixes #111 

This updates the logic behind `hasPreviousPage` and `hasNextPage` to follow the latest version of the Relay Cursor Connections spec:

https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo.Fields

When paginating forwards with `first` it's now permitted to return true when a previous page exists. Likewise, when paginating backwards with `last`, it's now permitted to return true when a next page exists. This is pretty handy for bidirectional pagination.

The tests for the `pageInfo` object were already in place, so I just updated the expectations.  Let me know if there are additional tests I should add.

Although it follows the spec, it seems like it could be a breaking change for users expecting the old behavior.