### PR TITLE
Include source_url in mix.exs so that code is linked from the docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule AbsintheRelay.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      package: package(),
-     docs: [source_ref: "v#{@version}", main: "Absinthe.Relay"],
+     docs: docs(),
      deps: deps()]
   end
 
@@ -21,6 +21,14 @@ defmodule AbsintheRelay.Mixfile do
      maintainers: ["Bruce Williams", "Ben Wilson"],
      licenses: ["MIT"],
      links: %{github: "https://github.com/absinthe-graphql/absinthe_relay"}]
+  end
+
+  defp docs do
+    [
+      source_ref: "v#{@version}",
+      main: "Absinthe.Relay",
+      source_url: "https://github.com/absinthe-graphql/absinthe_relay"
+    ]
   end
 
   def application do


### PR DESCRIPTION
When running ex_doc, if this value is set then each function will link
to the relevant line on GitHub.