### PR TITLE
Export local_without_parens for some macros

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,10 @@
+local_without_parens = [
+  connection: 1,
+  payload: 1
+]
+
 [
   inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
   import_deps: [:absinthe],
+  export: [local_without_parens: local_without_parens]
 ]


### PR DESCRIPTION
Hi, thank you for great product.

This pull request make the formatter config export `locals_without_parens` to be able to `import_deps` them. Mix formatter does not seem to add parens when `do` block is given so other macros, such as `node/1` and `connection/2`, are omitted.