### PR TITLE
Introduce a test and fix for ParseIDs to handle nullable input objects.

### DIFF
--- a/lib/absinthe/relay/node/parse_ids.ex
+++ b/lib/absinthe/relay/node/parse_ids.ex
@@ -349,6 +349,8 @@ defmodule Absinthe.Relay.Node.ParseIDs do
 
   defp format_child_value(_, [value]), do: value
 
+  defp format_child_value(nil, _), do: nil
+
   @spec find_child_schema_node(
           Absinthe.Type.identifier_t(),
           Absinthe.Type.Field.t() | Absinthe.Type.InputObject.t() | Absinthe.Type.Argument.t(),

--- a/test/lib/absinthe/relay/node/parse_ids_test.exs
+++ b/test/lib/absinthe/relay/node/parse_ids_test.exs
@@ -412,6 +412,31 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
 
       assert {:ok, %{data: %{"updateParent" => expected_parent_data}}} == result
     end
+    
+    test "works with null branch values" do
+      result =
+        """
+        mutation Foobar {
+          updateParent(input: {
+            clientMutationId: "abc",
+            parent: null
+          }) {
+            parent {
+              id
+              children { id }
+              child { id }
+            }
+          }
+        }
+        """
+        |> Absinthe.run(SchemaClassic)
+
+      expected_parent_data = %{
+        "parent" => nil
+      }
+
+      assert {:ok, %{data: %{"updateParent" => expected_parent_data}}} == result
+    end
 
     test "works with null leaf values" do
       result =


### PR DESCRIPTION
This pull request fixes a crash scenario when the `ParseIDs` middleware is used to decode opaque ids stored in a sub-field of a nullable argument.

With this change it will become possible to make a mutation call such as `mutation foo($input: null) { ... }` and allow for `ParseIDs` to be configured to decode `input: [some_id: :some_type]`