### PR TITLE
add connection/2 macro

### DIFF
--- a/lib/absinthe/relay/connection/notation.ex
+++ b/lib/absinthe/relay/connection/notation.ex
@@ -108,6 +108,11 @@ defmodule Absinthe.Relay.Connection.Notation do
     do_connection_definition(naming, attrs, block)
   end
 
+  defmacro connection(identifier, attrs) do
+    naming = naming_from_attrs!(attrs |> Keyword.put(:connection, identifier))
+    do_connection_definition(naming, attrs, [])
+  end
+
   defmacro connection(attrs) do
     naming = naming_from_attrs!(attrs)
     do_connection_definition(naming, attrs, [])

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -158,6 +158,8 @@ defmodule Absinthe.Relay.ConnectionTest do
       end
     end
 
+    connection(:favorite_pets_bare, node_type: :pet)
+
     connection :favorite_pets, node_type: :pet do
       field :fav_twice_edges_count, :integer do
         resolve fn _, %{source: conn} ->


### PR DESCRIPTION
Fixes #130. Ideally this bugfix would be backported to v1.4 too so it'd be in a non-beta release.