### PR TITLE
Fix typespec for from_query/5 options.

### DIFF
--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -3,10 +3,10 @@ defmodule Absinthe.Relay.Connection.Options do
 
   @typedoc false
   @type t :: %{
-          after: nil | integer,
-          before: nil | integer,
-          first: nil | integer,
-          last: nil | integer
+          optional(:after) => nil | integer,
+          optional(:before) => nil | integer,
+          optional(:first) => nil | integer,
+          optional(:last) => nil | integer
         }
 
   defstruct after: nil, before: nil, first: nil, last: nil


### PR DESCRIPTION
The current spec defined all the keys, but didn't mark them as optional. That means that if you skip a key (as opposed to explicitly setting it to nil), typechecking will fail.