### PR TITLE
fix: if offset is less than limit, set limit to offset

### DIFF
--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -496,7 +496,9 @@ defmodule Absinthe.Relay.Connection do
               {:ok, max(value - limit, 0), limit}
 
             {value, _} ->
-              {:ok, max(value - limit, 0), limit}
+              start_offset = max(value - limit, 0)
+              limit = if start_offset == 0, do: value, else: limit
+              {:ok, start_offset, limit}
           end
       end
     end

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -469,7 +469,7 @@ defmodule Absinthe.Relay.ConnectionTest do
                {:ok, 5, 5}
 
       assert Connection.offset_and_limit_for_query(%{last: 10, before: @offset_cursor_1}, []) ==
-               {:ok, 0, 10}
+               {:ok, 0, 1}
 
       assert Connection.offset_and_limit_for_query(%{last: 5, before: @offset_cursor_2}, []) ==
                {:ok, 0, 5}
@@ -480,6 +480,9 @@ defmodule Absinthe.Relay.ConnectionTest do
                []
              ) ==
                {:ok, 0, 5}
+
+      assert Connection.offset_and_limit_for_query(%{last: 3, before: @offset_cursor_2}, []) ==
+               {:ok, 2, 3}
     end
 
     test "without a cursor" do


### PR DESCRIPTION
from_list has handled, but from_query not

https://github.com/absinthe-graphql/absinthe_relay/blob/c3c85ca88adb8e925e846a515f75d93224b1f17d/lib/absinthe/relay/connection.ex#L338-L342