### PR TITLE
Bug fix: ignore nil first and last in pagination

### DIFF
--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -525,8 +525,8 @@ defmodule Absinthe.Relay.Connection do
   The direction and desired number of records in the pagination arguments.
   """
   @spec limit(args :: Options.t()) :: {:ok, pagination_direction, limit} | {:error, any}
-  def limit(%{first: first}), do: {:ok, :forward, first}
-  def limit(%{last: last}), do: {:ok, :backward, last}
+  def limit(%{first: first}) when not is_nil(first), do: {:ok, :forward, first}
+  def limit(%{last: last}) when not is_nil(last), do: {:ok, :backward, last}
   def limit(_), do: {:error, "You must either supply `:first` or `:last`"}
 
   @doc """

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -473,6 +473,13 @@ defmodule Absinthe.Relay.ConnectionTest do
 
       assert Connection.offset_and_limit_for_query(%{last: 5, before: @offset_cursor_2}, []) ==
                {:ok, 0, 5}
+
+      # Should be the same result even if nil :first and :after are provided:
+      assert Connection.offset_and_limit_for_query(
+               %{first: nil, after: nil, last: 5, before: @offset_cursor_2},
+               []
+             ) ==
+               {:ok, 0, 5}
     end
 
     test "without a cursor" do


### PR DESCRIPTION
Passing a `nil` value on a nullable input argument should be functionally equivalent to not passing that argument at all. This enables the client to always populate the `:first`/`:last`/`:before`/`:after` arguments, but use `null` values on the ones that should be ignored.

I included a test here which fails until this code change is made. We noticed this in our app because backward pagination wasn't working correctly on the following connection input arguments:

```json
{
  "after": null,
  "before": "YXJyYXljb25uZWN0aW9uOjI=",
  "first": null,
  "last": 2,
}
```

As I understand it, this _should_ produce the exact same output on a Relay connection with the following input arguments:

```json
{
  "before": "YXJyYXljb25uZWN0aW9uOjI=",
  "last": 2,
}
```

But without this PR's change, `absinthe_relay` does not handle these inputs the same way.

## Context from the Relay spec

Adding some additional context, the Relay Connection spec has this note:

> Including a value for both `first` and `last` is strongly discouraged, as it is likely to lead to confusing queries and results. The `PageInfo` section goes into more detail here.

And continues:

> When both `first` and `last` are included, both of the fields should be set according to the above algorithms, but their meaning as it relates to pagination becomes unclear. This is among the reasons that pagination with both `first` and `last` is discouraged.

However I don't believe what I've changed here is in conflict with this advice, because I am not include a **value** for both of these arguments; it's merely the existence of the key that causes this misbehavior.

## PR is on v1.4, not v1.5 RC

This is a PR to v1.4 because that is what we are still using in production due to #153. I haven't had time to produce a standalone demo of that bug but I tried again this week and was still having the same issue that prevents us from upgrading. I'll try to put that together soon and/or figure out the issue there.