### PR TITLE
Fix: default connection options type

### DIFF
--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -3,10 +3,10 @@ defmodule Absinthe.Relay.Connection.Options do
 
   @typedoc false
   @type t :: %{
-          optional(:after) => Connection.cursor(),
-          optional(:before) => Connection.cursor(),
-          optional(:first) => pos_integer(),
-          optional(:last) => pos_integer()
+          optional(:after) => nil | Connection.cursor(),
+          optional(:before) => nil | Connection.cursor(),
+          optional(:first) => nil | pos_integer(),
+          optional(:last) => nil | pos_integer()
         }
 
   defstruct after: nil, before: nil, first: nil, last: nil

--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -3,10 +3,10 @@ defmodule Absinthe.Relay.Connection.Options do
 
   @typedoc false
   @type t :: %{
-          optional(:after) => nil | integer,
-          optional(:before) => nil | integer,
-          optional(:first) => nil | integer,
-          optional(:last) => nil | integer
+          optional(:after) => Connection.cursor(),
+          optional(:before) => Connection.cursor(),
+          optional(:first) => pos_integer(),
+          optional(:last) => pos_integer()
         }
 
   defstruct after: nil, before: nil, first: nil, last: nil


### PR DESCRIPTION
Fix for issue #159 

Changes `before` and `after` parameters to `Connection.cursor()`, and `first` and `last` to positive integers.