### PR TITLE
Allow custom :id field type for node

### DIFF
--- a/lib/absinthe/relay/node.ex
+++ b/lib/absinthe/relay/node.ex
@@ -87,6 +87,32 @@ defmodule Absinthe.Relay.Node do
   Base64 implementation). All of this is handled for you automatically by
   prefixing your object type definition with `"node "`.
 
+  By default, type of `:id` field is `ID`. But you can pass custom type in `:id_type` attribute:
+
+  ```
+  node interface id_type: :uuid do
+      resolve_type fn
+        ...
+      end
+  end
+
+  node field id_type: :uuid do
+      resolve fn
+        ...
+      end
+  end
+
+  node object :thing, id_type: :uuid do
+    field :name, :string
+  end
+  ```
+
+  Or you can set it up globally via application config:
+  ```
+  config Absinthe.Relay,
+    node_id_type: :uuid
+  ```
+
   The raw, internal value is retrieved using `default_id_fetcher/2` which just
   pattern matches an `:id` field from the resolved object. If you need to
   extract/build an internal ID via another method, just provide a function as

--- a/test/lib/absinthe/relay/schema_test.exs
+++ b/test/lib/absinthe/relay/schema_test.exs
@@ -154,4 +154,151 @@ defmodule Absinthe.Relay.SchemaTest do
                Absinthe.run(@query, Schema)
     end
   end
+
+
+  defmodule SchemaCustomIdType do
+    use Absinthe.Schema
+    use Absinthe.Relay.Schema, :classic
+
+    @people %{
+      "jack" => %{id: "jack", name: "Jack", age: 35},
+      "jill" => %{id: "jill", name: "Jill", age: 31}
+    }
+    @businesses %{
+      "papers" => %{id: "papers", name: "Papers, Inc!", employee_count: 100},
+      "toilets" => %{id: "toilets", name: "Toilets International", employee_count: 1}
+    }
+    @cats %{"binx" => %{tag: "binx", name: "Mr. Binx", whisker_count: 12}}
+
+    query do
+      field :version, :string do
+        resolve fn _, _ ->
+          {:ok, "0.1.2"}
+        end
+      end
+
+      node field(id_type: :string) do
+        resolve fn
+          %{type: :person, id: id}, _ ->
+            {:ok, Map.get(@people, id)}
+
+          %{type: :business, id: id}, _ ->
+            {:ok, Map.get(@businesses, id)}
+
+          %{type: :cat, id: id}, _ ->
+            {:ok, Map.get(@cats, id)}
+        end
+      end
+    end
+
+    @desc "My Interface"
+    node interface(id_type: :string) do
+      resolve_type fn
+        %{age: _}, _ ->
+          :person
+
+        %{employee_count: _}, _ ->
+          :business
+
+        %{whisker_count: _}, _ ->
+          :cat
+
+        _, _ ->
+          nil
+      end
+    end
+
+    node object(:person, id_type: :string) do
+      field :name, :string
+      field :age, :string
+    end
+
+    node object(:business, id_type: :string) do
+      field :name, :string
+      field :employee_count, :integer
+    end
+
+    node object(:cat, name: "Kitten", id_fetcher: &tag_id_fetcher/2, id_type: :string) do
+      field :name, :string
+      field :whisker_count, :integer
+    end
+
+    defp tag_id_fetcher(%{tag: value}, _), do: value
+    defp tag_id_fetcher(_, _), do: nil
+  end
+
+  describe "using node interface with custom id type" do
+    test "creates the :node type" do
+      assert %Type.Interface{
+               name: "Node",
+               description: "My Interface",
+               fields: %{id: %Type.Field{name: "id", type: %Type.NonNull{of_type: :string}}}
+             } = SchemaCustomIdType.__absinthe_type__(:node)
+    end
+  end
+
+  describe "using node field with custom id type" do
+    test "creates the :node field" do
+      assert %{fields: %{node: %{name: "node", type: :node, middleware: middleware}}} =
+               SchemaCustomIdType.__absinthe_type__(:query)
+
+      middleware = Absinthe.Middleware.unshim(middleware, SchemaCustomIdType)
+
+      assert [
+               {Absinthe.Middleware.Telemetry, []},
+               {{Absinthe.Relay.Node, :resolve_with_global_id}, []},
+               {{Absinthe.Resolution, :call}, _}
+             ] = middleware
+    end
+  end
+
+  describe "using node object with custom id type" do
+    test "creates the object" do
+      assert %{name: "Kitten"} = SchemaCustomIdType.__absinthe_type__(:cat)
+    end
+  end
+
+  describe "using the node field and a global ID configured with an identifier and custom id type" do
+    @query """
+    {
+      node(id: "#{@jack_global_id}") {
+        id
+        ... on Person { name }
+      }
+    }
+    """
+    test "resolves using the global ID" do
+      assert {:ok, %{data: %{"node" => %{"id" => @jack_global_id, "name" => "Jack"}}}} =
+               Absinthe.run(@query, SchemaCustomIdType)
+    end
+  end
+
+  describe "using the node field and a global ID configured with a binary and custom id type" do
+    @query """
+    {
+      node(id: "#{@papers_global_id}") {
+        id
+        ... on Business { name }
+      }
+    }
+    """
+    test "resolves using the global ID" do
+      assert {:ok, %{data: %{"node" => %{"id" => @papers_global_id, "name" => "Papers, Inc!"}}}} =
+               Absinthe.run(@query, SchemaCustomIdType)
+    end
+  end
+
+  describe "using the node field and a custom id fetcher defined as an attribute and custom id type" do
+    @query """
+    {
+      node(id: "#{@binx_global_id}") {
+        id
+      }
+    }
+    """
+    test "resolves using the global ID" do
+      assert {:ok, %{data: %{"node" => %{"id" => @binx_global_id}}}} =
+               Absinthe.run(@query, SchemaCustomIdType)
+    end
+  end
 end


### PR DESCRIPTION
In one of my projects I'm using custom `UUID` type for all `:id` fields.
But node interface and objects have `:id` field with fixed `ID` type. Because of that resulting schema does not look consistent.

In this PR I've added `:id_type` attribute which allow one to pass his own types for `:id` fields.