### PR TITLE
fix: enable overriding the default cursor for an edge [#152] [#161]

### DIFF
--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -581,7 +581,7 @@ defmodule Absinthe.Relay.Connection do
   defp build_edge({item, args}, cursor) do
     args
     |> Enum.flat_map(fn
-      {key, _} when key in [:cursor, :node] ->
+      {key, _} when key in [:node] ->
         Logger.warn("Ignoring additional #{key} provided on edge (overriding is not allowed)")
         []
 

--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -566,7 +566,9 @@ defmodule Absinthe.Relay.Connection do
     offset = offset || 0
     first = offset_to_cursor(offset)
     edge = build_edge(item, first)
-    {edges, last} = do_build_cursors(items, offset + 1, [edge], first)
+    {edges, _} = do_build_cursors(items, offset + 1, [edge], first)
+    first = edges |> List.first() |> get_in([:cursor])
+    last = edges |> List.last() |> get_in([:cursor])
     {edges, first, last}
   end
 

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -578,20 +578,14 @@ defmodule Absinthe.Relay.ConnectionTest do
 
   describe "when provided with a cursor as an edge arg" do
     setup do
-      [record: {%{name: "Dan"}, %{role: "contributor", cursor: :bad}}]
+      [record: {%{name: "Dan"}, %{role: "contributor", cursor: "custom_cursor"}}]
     end
 
-    test "it will ignore the additional cursor", %{record: record} do
+    test "it will override the default cursor", %{record: record} do
       capture_log(fn ->
         {:ok, %{edges: [%{cursor: cursor} | _]}} = Connection.from_list([record], %{first: 1})
-        assert cursor == "YXJyYXljb25uZWN0aW9uOjA="
+        assert cursor == "custom_cursor"
       end)
-    end
-
-    test "it will log a warning", %{record: record} do
-      assert capture_log(fn ->
-               Connection.from_list([record], %{first: 1})
-             end) =~ "Ignoring additional cursor provided on edge"
     end
   end
 

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -580,8 +580,8 @@ defmodule Absinthe.Relay.ConnectionTest do
     setup do
       [
         records: [
-          {%{name: "Dan"}, %{role: "contributor", cursor: "first_custom_cursor"}},
-          {%{name: "Bob"}, %{role: "contributor", cursor: "end_custom_cursor"}}
+          {%{name: "Dan"}, %{role: "contributor", cursor: "start_cursor"}},
+          {%{name: "Bob"}, %{role: "contributor", cursor: "end_cursor"}}
         ]
       ]
     end
@@ -590,10 +590,10 @@ defmodule Absinthe.Relay.ConnectionTest do
       assert(
         {:ok,
          %{
-           edges: [%{cursor: "first_custom_cursor"}, %{cursor: "end_custom_cursor"}],
+           edges: [%{cursor: "start_cursor"}, %{cursor: "end_cursor"}],
            page_info: %{
-             start_cursor: "first_custom_cursor",
-             end_cursor: "end_custom_cursor"
+             start_cursor: "start_cursor",
+             end_cursor: "end_cursor"
            }
          }} = Connection.from_list(records, %{first: 2})
       )

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -582,10 +582,8 @@ defmodule Absinthe.Relay.ConnectionTest do
     end
 
     test "it will override the default cursor", %{record: record} do
-      capture_log(fn ->
-        {:ok, %{edges: [%{cursor: cursor} | _]}} = Connection.from_list([record], %{first: 1})
-        assert cursor == "custom_cursor"
-      end)
+      {:ok, %{edges: [%{cursor: cursor} | _]}} = Connection.from_list([record], %{first: 1})
+      assert cursor == "custom_cursor"
     end
   end
 

--- a/test/lib/absinthe/relay/connection_test.exs
+++ b/test/lib/absinthe/relay/connection_test.exs
@@ -578,12 +578,25 @@ defmodule Absinthe.Relay.ConnectionTest do
 
   describe "when provided with a cursor as an edge arg" do
     setup do
-      [record: {%{name: "Dan"}, %{role: "contributor", cursor: "custom_cursor"}}]
+      [
+        records: [
+          {%{name: "Dan"}, %{role: "contributor", cursor: "first_custom_cursor"}},
+          {%{name: "Bob"}, %{role: "contributor", cursor: "end_custom_cursor"}}
+        ]
+      ]
     end
 
-    test "it will override the default cursor", %{record: record} do
-      {:ok, %{edges: [%{cursor: cursor} | _]}} = Connection.from_list([record], %{first: 1})
-      assert cursor == "custom_cursor"
+    test "it will override the default cursor", %{records: records} do
+      assert(
+        {:ok,
+         %{
+           edges: [%{cursor: "first_custom_cursor"}, %{cursor: "end_custom_cursor"}],
+           page_info: %{
+             start_cursor: "first_custom_cursor",
+             end_cursor: "end_custom_cursor"
+           }
+         }} = Connection.from_list(records, %{first: 2})
+      )
     end
   end
 

--- a/test/lib/absinthe/relay/schema_test.exs
+++ b/test/lib/absinthe/relay/schema_test.exs
@@ -155,7 +155,6 @@ defmodule Absinthe.Relay.SchemaTest do
     end
   end
 
-
   defmodule SchemaCustomIdType do
     use Absinthe.Schema
     use Absinthe.Relay.Schema, :classic


### PR DESCRIPTION
This fixes #152 and #161 so that we are able to set custom cursors on edges.

As explained in #152, the reasons for why we may want to set and handle our own cursors are as follows:

1. We could be interfacing with external services that use their own cursors, or don't paginate using offset/limit.
2. Currently the cursors in this package just encode the OFFSET and OFFSET + LIMIT. But we may not want to use OFFSET in our SQL queries because it results in [slow performance for large offsets.](https://use-the-index-luke.com/sql/partial-results/fetch-next-page)
