### PR TITLE
Fix Elixir 1.11 compiles warning

### DIFF
--- a/lib/absinthe/relay/node/notation.ex
+++ b/lib/absinthe/relay/node/notation.ex
@@ -28,6 +28,22 @@ defmodule Absinthe.Relay.Node.Notation do
     do_interface(meta, attrs, block)
   end
 
+  defmacro node({:field, meta, [attrs]}, do: block) when is_list(attrs) do
+    do_field(meta, attrs, block)
+  end
+
+  defmacro node({:field, meta, attrs}, do: block) do
+    do_field(meta, attrs, block)
+  end
+
+  defmacro node({:object, meta, [identifier, attrs]}, do: block) when is_list(attrs) do
+    do_object(meta, identifier, attrs, block)
+  end
+
+  defmacro node({:object, meta, [identifier]}, do: block) do
+    do_object(meta, identifier, [], block)
+  end
+
   defp do_interface(meta, attrs, block) do
     attrs = attrs || []
     {id_type, attrs} = Keyword.pop(attrs, :id_type, get_id_type())
@@ -37,27 +53,11 @@ defmodule Absinthe.Relay.Node.Notation do
     {:interface, meta, attrs ++ [[do: block]]}
   end
 
-  defmacro node({:field, meta, [attrs]}, do: block) when is_list(attrs) do
-    do_field(meta, attrs, block)
-  end
-
-  defmacro node({:field, meta, attrs}, do: block) do
-    do_field(meta, attrs, block)
-  end
-
   defp do_field(meta, attrs, block) do
     attrs = attrs || []
     {id_type, attrs} = Keyword.pop(attrs, :id_type, get_id_type())
 
     {:field, meta, [:node, :node, attrs ++ [do: [field_body(id_type), block]]]}
-  end
-
-  defmacro node({:object, meta, [identifier, attrs]}, do: block) when is_list(attrs) do
-    do_object(meta, identifier, attrs, block)
-  end
-
-  defmacro node({:object, meta, [identifier]}, do: block) do
-    do_object(meta, identifier, [], block)
   end
 
   defp do_object(meta, identifier, attrs, block) do

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,10 @@ defmodule AbsintheRelay.Mixfile do
       start_permanent: Mix.env() == :prod,
       package: package(),
       docs: docs(),
-      deps: deps()
+      deps: deps(),
+      xref: [
+        exclude: [:ecto]
+      ]
     ]
   end
 


### PR DESCRIPTION
Fixes some compiles warnings:
1. https://github.com/absinthe-graphql/absinthe_relay/issues/171

2.
```
Generated ecto app

==> absinthe_relay

Compiling 22 files (.ex)

warning: clauses with the same name and arity (number of arguments) should be grouped together, "defmacro node/2" was previously defined (lib/absinthe/relay/node/notation.ex:23)

  lib/absinthe/relay/node/notation.ex:40

warning: clauses with the same name and arity (number of arguments) should be grouped together, "defmacro node/2" was previously defined (lib/absinthe/relay/node/notation.ex:23)

  lib/absinthe/relay/node/notation.ex:55
```