### PR TITLE
Use Github Actions instead of TravisCI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - elixir: '1.11'
+            otp: '23'
+          - elixir: '1.10'
+            otp: '22'
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Elixir
+      uses: actions/setup-elixir@v1
+      with:
+        elixir-version: ${{ matrix.elixir }}
+        otp-version: ${{ matrix.otp }}
+
+    - name: Restore deps cache
+      uses: actions/cache@v2
+      with:
+        path: deps
+        key: ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          ${{ runner.os }}-mix-${{ matrix.otp }}-${{ matrix.elixir }}
+          ${{ runner.os }}-mix-${{ matrix.otp }}
+          ${{ runner.os }}-mix
+
+    - name: Restore _build cache
+      uses: actions/cache@v2
+      with:
+        path: _build
+        key: ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          ${{ runner.os }}-build-${{ matrix.otp }}-${{ matrix.elixir }}
+          ${{ runner.os }}-build-${{ matrix.otp }}
+          ${{ runner.os }}-build
+
+    - name: Install Dependencies
+      run: |
+        mix local.hex --force
+        mix local.rebar --force
+        mix deps.get --only test
+
+    - name: Run unit tests
+      run: |
+        mix clean
+        mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: elixir
-elixir: 1.9
-notifications:
-  recipients:
-    - bruce.williams@cargosense.com
-    - ben.wilson@cargosense.com
-otp_release:
-  - 22.0
-script: "MIX_ENV=test mix local.hex --force && MIX_ENV=test mix do deps.get, test"


### PR DESCRIPTION
Hello.

I've realized that there are no tests running at commit/PR into your repo.
It seems that you've previously used TravisCI for that. I'm not sure why is it disabled now, but I faced the issue with their new billing plans and too strict limitations for running builds for open source projects.

What do you think about migrating to Github Actions? It's actually quite easy to do.