### PR TITLE
fix Dialyzer warnings

### DIFF
--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -1,6 +1,6 @@
 defmodule Absinthe.Relay.Connection.Options do
   @moduledoc false
-  
+
   alias Absinthe.Relay.Connection
 
   @typedoc false

--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -1,12 +1,15 @@
 defmodule Absinthe.Relay.Connection.Options do
   @moduledoc false
+  
+  alias Absinthe.Relay.Connection
 
   @typedoc false
   @type t :: %{
           optional(:after) => nil | Connection.cursor(),
           optional(:before) => nil | Connection.cursor(),
           optional(:first) => nil | pos_integer(),
-          optional(:last) => nil | pos_integer()
+          optional(:last) => nil | pos_integer(),
+          optional(any()) => any()
         }
 
   defstruct after: nil, before: nil, first: nil, last: nil
@@ -324,7 +327,7 @@ defmodule Absinthe.Relay.Connection do
   end
   ```
   """
-  @spec from_list(data :: list, args :: Option.t()) :: {:ok, t} | {:error, any}
+  @spec from_list(data :: list, args :: Options.t()) :: {:ok, t} | {:error, any}
   def from_list(data, args, opts \\ []) do
     with {:ok, direction, limit} <- limit(args, opts[:max]),
          {:ok, offset} <- offset(args) do


### PR DESCRIPTION
This PR fixes a couple dialyzer warnings around missing types. Additionally, it allows other keys in maps passed to functions that expect `Absinthe.Relay.Connection.Options.t()` (useful for when these arguments come from Absinthe resolver args, where other unrelated args may also be present).

```elixir
defmodule MyApp.Schema do
  query do
    connection(field(:users)) do
      arg :is_banned, non_null(:boolean)

      resolve fn _, %{is_banned: is_banned} = args, _ ->
        users = UsersService.list()
        Connection.from_list(users, args) # this line raises a dialyzer warning,
                                          # because `args` has a key named
                                          # `:is_banned`; this shouldn't warn,
                                          # since unrecognized keys are ignored
      end
    end
  end
end
```