### PR TITLE
Patch broken link in Absinthe.Relay.Node

### DIFF
--- a/lib/absinthe/relay/node.ex
+++ b/lib/absinthe/relay/node.ex
@@ -7,7 +7,7 @@ defmodule Absinthe.Relay.Node do
   interface for querying them.
 
   More information can be found at:
-  - https://facebook.github.io/relay/docs/graphql-object-identification.html#content
+  - https://relay.dev/docs/guides/graphql-server-specification/#object-identification
   - https://facebook.github.io/relay/graphql/objectidentification.htm
 
   ## Interface


### PR DESCRIPTION
I replaced the link with the relay guide to object identification. 
The other option is to use the article in graphql.org
https://graphql.org/learn/global-object-identification/