### PR TITLE
Parse ids and meta info

### DIFF
--- a/test/lib/absinthe/relay/node/parse_ids_test.exs
+++ b/test/lib/absinthe/relay/node/parse_ids_test.exs
@@ -162,6 +162,25 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
 
         resolve &resolve_parent/2
       end
+
+      payload field(:update_parent_local_middleware_with_meta, meta: [key: :val]) do
+        input do
+          field :parent, :parent_input
+        end
+
+        output do
+          field :parent, :parent
+        end
+
+        middleware Absinthe.Relay.Node.ParseIDs,
+          parent: [
+            id: :parent,
+            children: [id: :child],
+            child: [id: :child]
+          ]
+
+        resolve &resolve_parent/2
+      end
     end
 
     defp resolve_foo(%{foo_id: id}, _) do
@@ -289,6 +308,25 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
 
     mutation do
       payload field(:update_parent_local_middleware) do
+        input do
+          field :parent, :parent_input
+        end
+
+        output do
+          field :parent, :parent
+        end
+
+        middleware Absinthe.Relay.Node.ParseIDs,
+          parent: [
+            id: :parent,
+            children: [id: :child],
+            child: [id: :child]
+          ]
+
+        resolve &resolve_parent/2
+      end
+
+      payload field(:update_parent_local_middleware_with_meta, meta: [key: :val]) do
         input do
           field :parent, :parent_input
         end
@@ -696,6 +734,68 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
       }
 
       assert {:ok, %{data: %{"updateParentLocalMiddleware" => expected_parent_data}}} == result
+    end
+
+    test "for classic schema with meta" do
+      result =
+        """
+        mutation FoobarLocal {
+          updateParentLocalMiddlewareWithMeta(input: {
+            clientMutationId: "abc",
+            parent: {
+              id: "#{@parent1_id}",
+              children: [{ id: "#{@child1_id}"}, {id: "#{@child2_id}"}, {id: null}],
+              child: { id: "#{@child2_id}"}
+            }
+          }) {
+            parent {
+              id
+              children { id }
+              child { id }
+              }
+            }
+        }
+        """
+        |> Absinthe.run(SchemaClassic)
+
+      expected_parent_data = %{
+        "parent" => %{
+          # The output re-converts everything to global_ids.
+          "id" => @parent1_id,
+          "children" => [%{"id" => @child1_id}, %{"id" => @child2_id}, nil],
+          "child" => %{
+            "id" => @child2_id
+          }
+        }
+      }
+
+      assert {:ok, %{data: %{"updateParentLocalMiddlewareWithMeta" => expected_parent_data}}} == result
+    end
+
+    test "for modern schema with meta" do
+      result =
+        """
+        mutation FoobarLocal {
+          updateParentLocalMiddlewareWithMeta(input: {
+            parent: {
+              id: "#{@modern_parent1_id}",
+            }
+          }) {
+            parent {
+              id
+            }
+          }
+        }
+        """
+        |> Absinthe.run(SchemaModern)
+
+      expected_parent_data = %{
+        "parent" => %{
+          "id" => @modern_parent1_id
+        }
+      }
+
+      assert {:ok, %{data: %{"updateParentLocalMiddlewareWithMeta" => expected_parent_data}}} == result
     end
   end
 

--- a/test/lib/absinthe/relay/node/parse_ids_test.exs
+++ b/test/lib/absinthe/relay/node/parse_ids_test.exs
@@ -799,7 +799,7 @@ defmodule Absinthe.Relay.Node.ParseIDsTest do
     end
   end
 
-  describe "ParseIDs middlware in both mutation and child field" do
+  describe "ParseIDs middleware in both mutation and child field" do
     test "classic schema" do
       result =
         """


### PR DESCRIPTION
When you have a field that has metadata attached to it such as:
```
payload field(:update_parent_local_middleware_with_meta, meta: [key: :val]) do
...
```
it puts that metadata into `%{__private__: [meta: [key: :val]]}`. But that makes it so that the existing pattern match in `find_schema_root!` no longer works because keyword list pattern matching is awkward and it eventually raises the error `"Could not find schema_node for #{key}"`.

This PR makes it so that it doesn't try to pattern match on the keyword list, but moves the match into the function body itself, returning the original fallback if the match does not work.