### PR TITLE
With restricted pagination, force first or last to be given

### DIFF
--- a/lib/absinthe/relay/connection/notation.ex
+++ b/lib/absinthe/relay/connection/notation.ex
@@ -343,15 +343,15 @@ defmodule Absinthe.Relay.Connection.Notation do
   end
 
   defp paginate_args(:forward) do
-    [after: :string, first: :integer]
+    [after: :string, first: %Absinthe.Blueprint.TypeReference.NonNull{of_type: :integer}]
   end
 
   defp paginate_args(:backward) do
-    [before: :string, last: :integer]
+    [before: :string, last: %Absinthe.Blueprint.TypeReference.NonNull{of_type: :integer}]
   end
 
   defp paginate_args(:both) do
-    paginate_args(:forward) ++ paginate_args(:backward)
+    [after: :string, first: :integer, before: :string, last: :integer]
   end
 
   defp build_arg(id, type) do


### PR DESCRIPTION
When a connection is set up with `paginate: :forward` or `paginate: :backward`, the corresponding slice argument (`first` or `last`) is actually required.

This change creates the right type `Int!` for the argument in those cases.