### PR TITLE
add global id fetcher configurability

### DIFF
--- a/lib/absinthe/relay/node.ex
+++ b/lib/absinthe/relay/node.ex
@@ -127,6 +127,12 @@ defmodule Absinthe.Relay.Node do
   end
   ```
 
+  Or you can set it up globally via application config:
+  ```
+  config Absinthe.Relay,
+    node_id_fetcher: &my_custom_id_fetcher/2
+  ```
+
   For instructions on how to change the underlying method of decoding/encoding
   a global ID, see `Absinthe.Relay.Node.IDTranslator`.
 

--- a/lib/absinthe/relay/node/notation.ex
+++ b/lib/absinthe/relay/node/notation.ex
@@ -61,7 +61,7 @@ defmodule Absinthe.Relay.Node.Notation do
   end
 
   defp do_object(meta, identifier, attrs, block) do
-    {id_fetcher, attrs} = Keyword.pop(attrs, :id_fetcher)
+    {id_fetcher, attrs} = Keyword.pop(attrs, :id_fetcher, get_id_fetcher())
     {id_type, attrs} = Keyword.pop(attrs, :id_type, get_id_type())
 
     block = [
@@ -95,6 +95,11 @@ defmodule Absinthe.Relay.Node.Notation do
   defp get_id_type() do
     Absinthe.Relay
     |> Application.get_env(:node_id_type, :id)
+  end
+
+  defp get_id_fetcher() do
+    Absinthe.Relay
+    |> Application.get_env(:node_id_fetcher)
   end
 
   # An id field is automatically configured


### PR DESCRIPTION
In our project, we'd love the ability to specify a global `id_fetcher` since all of our objects are using uuids and we don't want to use the DB`id`.