### PR TITLE
Fix Logger warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install from [Hex.pm](https://hex.pm/packages/absinthe_relay):
 ```elixir
 def deps do
   [
-    {:absinthe_relay, "~> 1.6.0"}
+    {:absinthe_relay, "~> 1.5.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ Install from [Hex.pm](https://hex.pm/packages/absinthe_relay):
 ```elixir
 def deps do
   [
-    {:absinthe_relay, "~> 1.5.0"}
+    {:absinthe_relay, "~> 1.6.0"}
   ]
 end
 ```
 
-Note: Absinthe.Relay requires Elixir 1.10 or higher.
+Note: Absinthe.Relay requires Elixir 1.11 or higher.
 
 ## Upgrading
 

--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -587,7 +587,7 @@ defmodule Absinthe.Relay.Connection do
     args
     |> Enum.flat_map(fn
       {key, _} when key in [:node] ->
-        Logger.warn("Ignoring additional #{key} provided on edge (overriding is not allowed)")
+        Logger.warning("Ignoring additional #{key} provided on edge (overriding is not allowed)")
         []
 
       {key, val} ->

--- a/lib/absinthe/relay/node.ex
+++ b/lib/absinthe/relay/node.ex
@@ -264,7 +264,7 @@ defmodule Absinthe.Relay.Node do
         global_id
 
       {:error, err} ->
-        Logger.warn(
+        Logger.warning(
           "Failed to translate (#{inspect(node_type)}, #{inspect(source_id)}) to global ID with error: #{err}"
         )
 
@@ -371,7 +371,7 @@ defmodule Absinthe.Relay.Node do
   # Reports a failure to fetch an ID
   @spec report_fetch_id_error(type_name :: String.t(), source :: any) :: {:error, String.t()}
   defp report_fetch_id_error(type_name, source) do
-    Logger.warn(@missing_internal_id_error <> " (type #{type_name})")
+    Logger.warning(@missing_internal_id_error <> " (type #{type_name})")
     Logger.debug(inspect(source))
     {:error, @missing_internal_id_error}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule AbsintheRelay.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/absinthe-graphql/absinthe_relay"
-  @version "1.6.0"
+  @version "1.5.3"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule AbsintheRelay.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/absinthe-graphql/absinthe_relay"
-  @version "1.5.2"
+  @version "1.6.0"
 
   def project do
     [


### PR DESCRIPTION
Changed deprecated `Logger.warn` to `Logger.warning`
Updated README to min Elixir 1.11
On CI we already started from 1.11
```
        include:
          - pair:
              elixir: "1.11.x"
              otp: "22.x"
          - pair:
              elixir: "1.15.x"
              otp: "26.x"
```

Updated version to `1.6`, maybe use 1.5.3 is better?